### PR TITLE
Update all-in-one README

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -52,7 +52,7 @@ Example:
 docker run -p 8080:8080 -v "$(pwd)"/oscal-content:/app/oscal-content ghcr.io/easydynamics/easygrc-all-in-one
 ```
 
-The container will run both the OSCAL Viewer and REST Service on startup. The OSCAL Viewer is available at the port specified in the run command, eg. `http://localhost:8080`, and HTTP requests can be made to the REST Service at the same port following the [OSCAL Rest API specification.](https://github.com/EasyDynamics/oscal-rest), eg. `http://localhost:8080/oscal/v1/ssps/cff8385f-108e-40a5-8f7a-82f3dc0eaba8`
+The container will run both the OSCAL Viewer and REST Service on startup. The OSCAL Viewer is available at the port specified in the run command, eg. `http://localhost:8080`, and HTTP requests can be made to the REST Service at the same port following the [OSCAL Rest API specification.](https://github.com/EasyDynamics/oscal-rest), eg. http://localhost:8080/oscal/v1/ssps/cff8385f-108e-40a5-8f7a-82f3dc0eaba8
 
 ### Manually Configuring Directory Paths
 


### PR DESCRIPTION
Update the all-in-one README to reflect changes made in the `oscal-rest-service` repository, as we can now use human readable file names. 

This PR should not be merged before [the PR](https://github.com/EasyDynamics/oscal-rest-service/pull/30) in the `oscal-rest-service`, so that the README stays reflective of the current state of the rest service.