### PR TITLE
Correct Environment Variable Names

### DIFF
--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -19,7 +19,7 @@ USER easygrc
 #set environment variables for the oscal content directory
 #and location of the production build to be served by Spring Boot
 ENV PERSISTENCE_FILE_PARENT_PATH="oscal-content" \
-    SPRING_RESOURCES_STATIC_LOCATIONS="file:/app/build/"
+    SPRING_WEB_RESOURCES_STATIC_LOCATIONS="file:/app/build/"
 
 EXPOSE 8080
 

--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -59,11 +59,11 @@ The container will run both the OSCAL Viewer and REST Service on startup. The OS
 ### Manually Configuring Directory Paths
 
 If needed, the directory and sub-directory paths of the OSCAL content directory can also be manually configured by overwriting these environment variables in the container:
-- `PERSISTENT_FILE_PARENT_PATH`
-- `PERSISTENT_FILE_CATALOGS_PATH`
-- `PERSISTENT_FILE_COMPONENT_DEFINITIONS_PATH`
-- `PERSISTENT_FILE_PROFILES_PATH`
-- `PERSISTENT_FILE_SSPS_PATH` 
+- `PERSISTENCE_FILE_PARENT_PATH`
+- `PERSISTENCE_FILE_CATALOGS_PATH`
+- `PERSISTENCE_FILE_COMPONENT_DEFINITIONS_PATH`
+- `PERSISTENCE_FILE_PROFILES_PATH`
+- `PERSISTENcE_FILE_SSPS_PATH`
 
 The environment variables can be set using the `-e` flag of the `docker run` command.
 


### PR DESCRIPTION
Change the name of the environment variable that handles static files
in the Dockerfile to the correct name.

Also update the README to fix the incorrect environment variable
names for the persistence file paths.