### PR TITLE
Remove hardcoded path from Cypress spec

### DIFF
--- a/.github/workflows/deploy-all-in-one.yml
+++ b/.github/workflows/deploy-all-in-one.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v2
         with:
-          spec: cypress/integration/OSCAL/OSCAL_URL_Test.spec.js
+          spec: cypress/integration/**/*.spec.js
           working-directory: end-to-end-tests
 
       - name: Stop Running Container


### PR DESCRIPTION
This file was recently renamed. We should instead use a glob/wildcard in
order to just grab all the `.spec.js` files under `integration/`.
https://github.com/cypress-io/github-action#specs
