### PR TITLE
Add default static classpath to static locations

### DIFF
--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -47,7 +47,7 @@ USER oscaledit
 #set environment variables for the oscal content directory
 #and location of the production build to be served by Spring Boot
 ENV PERSISTENCE_FILE_PARENT_PATH="oscal-content" \
-    SPRING_WEB_RESOURCES_STATIC_LOCATIONS="file:/app/build/"
+    SPRING_WEB_RESOURCES_STATIC_LOCATIONS="classpath:/static,file:/app/build/"
 
 EXPOSE 8080
 


### PR DESCRIPTION
Without this the Swagger UI (http://localhost:8080/swagger-ui/index.html) is broken in Docker.