### PR TITLE
Add a basic workflow for running tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,72 @@
+name: Build container and run end-to-end tests
+on:
+  pull_request:
+    
+
+env:
+  IMAGE_NAME: oscal-editor-all-in-one-test
+  CONTAINER_NAME: test_container
+
+jobs:
+  build_test_deploy:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install Tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq xmlstarlet curl wget
+
+      # Install the latest versions of the OSCAL Viewer and
+      # OSCAL REST Service from GitHub packages
+      - name: Pull OSCAL Viewer and OSCAL REST Service
+        run: ./packages_pull.sh
+        working-directory: all-in-one
+        env:
+          OSCAL_EDITOR_GITHUB_PACKAGES_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+      # Get Default OSCAL Content for testing
+      - name: Pull OSCAL Content
+        uses: actions/checkout@v3
+        with:
+          repository: EasyDynamics/oscal-demo-content
+          path: all-in-one/oscal-content
+
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Build the Docker image, and load it locally so it can be run for testing
+      - name: Build Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./all-in-one
+          file: ./all-in-one/Dockerfile
+          load: true
+          tags: ${{ env.IMAGE_NAME }}
+
+      # Run container in the background, exposing the port that
+      # Cypress uses to run the tests.
+      - name: Run Docker Container for Tests
+        run: |
+          docker run --rm -p 8080:8080 \
+          -v $(pwd)/all-in-one/oscal-content:/app/oscal-content \
+          --name ${CONTAINER_NAME} ${IMAGE_NAME} &
+
+      - name: Run Cypress Tests
+        uses: cypress-io/github-action@v2
+        with:
+          spec: cypress/integration/**/*.spec.js
+          working-directory: end-to-end-tests
+
+      # Upload the screenshots and videos of a Cypress test failure
+      # to the artifacts of this workflow on GitHub
+      - name: Upload Cypress Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cypress-results
+          path: |
+            ./end-to-end-tests/cypress/screenshots
+            ./end-to-end-tests/cypress/videos

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ node_modules
 .project
 .settings
 all-in-one/build/
-all-in-one/oscal-rest-service-0.0.1-SNAPSHOT.jar
 all-in-one/oscal-content/
-all-in-one/oscal-rest-service.jar
 all-in-one/viewer.zip
 all-in-one/viewer
+all-in-one/*.jar

--- a/all-in-one/packages_pull.sh
+++ b/all-in-one/packages_pull.sh
@@ -89,7 +89,7 @@ get-rest-service-jar() (
 
   local package_version
   package_version="$(authenticated-v3-api-request "$request_url" "$token" | jq --raw-output '.[0].name' 2> /dev/null)"
-  
+
   if [ "$?" -ne 0 ] || [ -z "$package_version" ] ; then
     echo "!!! Unable to get OSCAL Rest Service package version"
     echo "    Check the provided PAT has sufficient permissions and try again"
@@ -133,7 +133,9 @@ main() (
     exit 1
   fi
 
-  if [[ ! "$token" =~ ^ghp_ ]]; then
+  # Formats based on:
+  # https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/
+  if [[ ! "$token" =~ ^gh[pousr]_ ]]; then
     echo "!!! The provided GitHub PAT is invalid"
     exit 1
   fi


### PR DESCRIPTION
This isn't particularly elegant and mostly copies and pastes the
workflow we use for deploying (for the most part). I don't want to
consider this to be good enough for #37. We need to do more work
but with the recent set of changes, I think this will be valuable
so we don't have to merge a PR just to see if it fixes the tests.
