### PR TITLE
Use a relative URL for the REST API base

### DIFF
--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache git
 ARG OSCAL_REACT_GIT_REPO=https://github.com/EasyDynamics/oscal-react-library
 ARG OSCAL_REACT_GIT_BRANCH=develop
 ARG OSCAL_REACT_DIR=oscal-react-library
-ARG OSCAL_REST_BASE_URL=http://localhost:8080/oscal/v1
+ARG OSCAL_REST_BASE_URL=/oscal/v1
 ARG VIEWER_PATH
 
 WORKDIR /app


### PR DESCRIPTION
Users may attempt to access the viewer from across a network rather than
directly on their machine. Hardcoding the `OSCAL_REST_BASE_URL` to
`localhost` means that if a user accesses the application over a network
(imagine, at the IP address `192.168.1.20`), their API requests will go
to `http://localhost:8080/oscal/v1/catalogs` rather than to
`http://192.168.1.20/oscal/v1/catalogs`.

The viewer application uses the `fetch` API within browsers to make the
requests to the API. `fetch` supports querying a relative URL (and in
fact does so automatically).

The REST API service and the viewer application will be served from the
same port on the same IP. Therefore, we can use a relative path to
support queries when the container is accessed over a network.

This resolves the bug for the specific use case highlighted in #48; however,
we may need to consider longer-term enhancements for configuration.