### PR TITLE
Support arbitrary `oscal-rest-service` branches

### DIFF
--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -25,14 +25,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install jq xmlstarlet curl wget
 
-      # Install the latest versions of the OSCAL Viewer and
-      # OSCAL REST Service from GitHub packages
-      - name: Pull OSCAL Viewer and OSCAL REST Service
-        run: ./packages_pull.sh
-        working-directory: all-in-one
-        env:
-          OSCAL_EDITOR_GITHUB_PACKAGES_PAT: ${{ secrets.GITHUB_TOKEN }}
-
       # Get Default OSCAL Content for testing
       - name: Pull OSCAL Content
         uses: actions/checkout@v3
@@ -50,9 +42,6 @@ jobs:
           context: ./all-in-one
           load: true
           tags: ${{ env.IMAGE_NAME }}
-          build-args: |
-            VIEWER_PATH=./viewer
-            REST_PATH=./oscal-rest-service.jar
 
       # Run container in the background, exposing the port that
       # Cypress uses to run the tests.
@@ -133,6 +122,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VIEWER_PATH=./viewer
-            REST_PATH=./oscal-rest-service.jar

--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -50,6 +50,9 @@ jobs:
           context: ./all-in-one
           load: true
           tags: ${{ env.IMAGE_NAME }}
+          build-args: |
+            VIEWER_PATH=./viewer
+            REST_PATH=./oscal-rest-service.jar
 
       # Run container in the background, exposing the port that
       # Cypress uses to run the tests.
@@ -130,3 +133,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VIEWER_PATH=./viewer
+            REST_PATH=./oscal-rest-service.jar

--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -1,6 +1,23 @@
-FROM node:18.0.0-alpine as build-viewer
+# The build operates in three phases:
+#  1. Build the oscal-react-library example app. This phase happens in a
+#     Node environment. If a prebuilt viewer is provided, that is used.
+#     Otherwise, the repository is cloned and the viewer is built.
+#  2. Build the oscal-rest-service. This phase happens in an OpenJDK image.
+#     Like with the viewer, if a prebuilt JAR file is provided, that is used.
+#     Otherwise, the service is built from source.
+#  3. The final "runtime" container is built. This is based off an OpenJDK JRE
+#     container with minimal additional software installed.
+#  Steps 1 & 2 place their artifacts in /app/ and Step 3 copies the final artifact
+#  into its /app/ directory with the appropriate filename.
 
-RUN apk add --no-cache git
+ARG JAVA_VERSION=11
+ARG NODE_VERSION=lts
+# The maven container specifies a JAVA_VERSION environment variable so we have
+# to find a way to rename our variable within that stage. ENV always overrides
+# ARG, apparently even when it was set in a base image.
+ARG _JAVA_VERSION=${JAVA_VERSION}
+
+FROM node:${NODE_VERSION}-alpine as build-viewer
 
 ARG OSCAL_REACT_GIT_REPO=https://github.com/EasyDynamics/oscal-react-library
 ARG OSCAL_REACT_GIT_BRANCH=develop
@@ -13,9 +30,10 @@ WORKDIR /app
 # Copy the (possibly empty/undefined) viewer app into build
 COPY $VIEWER_PATH /app/build
 # If VIEWER_PATH has been defined, otherwise build from source
-RUN if [[ -n "$VIEWER_PATH" ]] ; \
+RUN if [ -n "$VIEWER_PATH" ] ; \
     then echo "Using viewer from $VIEWER_PATH" ; \
-    else rm -rf /app/build && \
+    else apk add --no-cache git && \
+    rm -rf /app/build && \
     git clone --branch "$OSCAL_REACT_GIT_BRANCH" --depth 1 -- "$OSCAL_REACT_GIT_REPO" "$OSCAL_REACT_DIR" && \
     cd "$OSCAL_REACT_DIR" && \
     npm ci && \
@@ -25,16 +43,34 @@ RUN if [[ -n "$VIEWER_PATH" ]] ; \
     mv build /app/ ; \
     fi
 
+FROM maven:3-openjdk-${JAVA_VERSION} as build-service
+ARG _JAVA_VERSION
 
-FROM openjdk:11-jre-slim
+ARG OSCAL_REST_SERVICE_GIT_REPO=https://github.com/EasyDynamics/oscal-rest-service
+ARG OSCAL_REST_SERVICE_GIT_BRANCH=develop
+ARG OSCAL_REST_SERVICE_DIR=oscal-rest-service
+ARG REST_PATH
 
-ARG REST_PATH=./oscal-rest-service.jar
+WORKDIR /app
 
-#copy .jar of OSCAL REST Service
-COPY $REST_PATH /app/rest.jar
+COPY $REST_PATH /app/oscal-rest-service-app.jar
+
+RUN if [ -n "$REST_PATH" ]; \
+    then echo "Using REST service from $REST_PATH"; \
+    else rm -rf /app/oscal-rest-service-app.jar && \
+    git clone --branch "${OSCAL_REST_SERVICE_GIT_BRANCH}" --depth 1 -- "${OSCAL_REST_SERVICE_GIT_REPO}" "${OSCAL_REST_SERVICE_DIR}" && \
+    cd "${OSCAL_REST_SERVICE_DIR}" && \
+    mvn -Djava.version="${_JAVA_VERSION}" clean install && \
+    # Even though we use a * glob here, there should only be one file that matches this spec. Using the
+    # glob means that we don't have to worry about the specified version in the `pom.xml`
+    mv oscal-rest-service-app/target/oscal-rest-service-app*.jar "/app/oscal-rest-service-app.jar"; \
+    fi
+
+FROM openjdk:${JAVA_VERSION}-slim-bullseye
 
 #copy production build of OSCAL Viewer
-COPY --from=build-viewer /app/build /app/build
+COPY --from=build-viewer /app/build /app/oscal-viewer-app
+COPY --from=build-service /app/oscal-rest-service-app.jar /app/oscal-rest-service-app.jar
 
 #add a new group and add a new user to the group
 #give permissions in the /app/ directory to the new user
@@ -47,10 +83,10 @@ USER oscaledit
 #set environment variables for the oscal content directory
 #and location of the production build to be served by Spring Boot
 ENV PERSISTENCE_FILE_PARENT_PATH="oscal-content" \
-    SPRING_WEB_RESOURCES_STATIC_LOCATIONS="classpath:/static,file:/app/build/"
+    SPRING_WEB_RESOURCES_STATIC_LOCATIONS="classpath:/static,file:/app/oscal-viewer-app/"
 
 EXPOSE 8080
 
 WORKDIR /app/
 
-ENTRYPOINT ["java", "-jar", "rest.jar"]
+ENTRYPOINT ["java", "-jar", "oscal-rest-service-app.jar"]

--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -4,7 +4,7 @@ Simple Docker deployment of the back-end services and web-based user interface f
 
 ## Pulling the Image
 
-The Docker image is hosted on the [GitHub Container Registry.](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+The Docker image is hosted on the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
 
 You can pull the image by running:
 ```
@@ -55,57 +55,61 @@ The environment variables can be set using the `-e` flag of the `docker run` com
 
 ## Building the Image Locally
 
-To build the Docker image manually instead of pulling from the registry, you'll need:
-- The Dockerfile (provided in this repo)
-- The [OSCAL Viewer](https://github.com/EasyDynamics/oscal-react-library)
-  - Only needed if building for specific changes, otherwise GitHub source is used
-- The [OSCAL REST Service](https://github.com/EasyDynamics/oscal-rest-service)
+The Docker image can be built locally, instead of being pulled from the registry, by using the
+`Dockerfile` provided within this repository. Optionally, you can provide prebuilt copies of the
+[OSCAL Viewer][react-lib] and the [OSCAL REST Service][service]; however, if those are not provided
+the `Dockerfile` will automatically fetch the source from GitHub and build them when building the
+container.
 
-The latest versions of the OSCAL Viewer and OSCAL REST Service are hosted on [GitHub Packages.](https://github.com/orgs/EasyDynamics/packages) They can be easily downloaded using the `packages_pull.sh` bash script in this repo. Authentication to download from GitHub Packages requires a [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `package:read` permissions.
+The latest tagged version of the [OSCAL Viewer][viewer] is available as a
+[build artifact][viewer-artifact] of the latest release of the [`oscal-react-library`][react-lib].
+You may download that file, pass it as the `VIEWER_PATH` build arg as described below. The latest
+snapshot release of the [OSCAL REST Service][service] is hosted on [GitHub packages][package].
 
-Example:
-```
-bash packages_pull.sh {GitHub Packages PAT}
-``` 
+You may optionally download both the latest version of the OSCAL Viewer and REST Service using the
+`packages_pull.sh` shell script in this directory. In order to use the script, you will need to
+leverage a GitHub [PAT][pat]. The script can be invoked as `packages_pull.sh <PAT>`. The downloaded
+files may be passed to the `VIEWER_PATH` and `REST_PATH` build args as described below.
 
-### Building Required Resources
+[react-lib]: https://github.com/EasyDynamics/oscal-react-library
+[viewer]: https://github.com/EasyDynamics/oscal-react-library/tree/develop/example
+[service]: https://github.com/EasyDynamics/oscal-rest-service
+[viewer-artifact]: https://github.com/EasyDynamics/oscal-react-library/releases/latest/download/oscal-viewer.zip
+[package]: https://github.com/EasyDynamics/oscal-rest-service/packages/1369238
+[pat]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 
-To build a specific version of the OSCAL Viewer or OSCAL REST Service:
-
-Clone the OSCAL Viewer and build the production build by running `npm install && npm run build` in the `example` directory. This will create the `example/build/` directory.
-
-Clone the OSCAL REST Service compile it into a .jar with `mvn install`. The .jar file will be written to `oscal-rest-service-{version}.jar` in the `target` directory.
-
-More in-depth docs on building these resources can be found on their respective GitHub pages, linked above.
 
 ### Creating the Image
 
-Once the required resources are set up, run `docker build --tag oscal-editor-all-in-one .`
+The image can be built by running `docker build --tag oscal-editor-all-in-one .`.
 
-By default, the Dockerfile will build the OSCAL Viewer from source and look for an `oscal-rest-service.jar` file in the current directory. 
-To specify a local OSCAL Viewer distribution build use the `VIEWER_PATH` build argument. To provide a different path to the REST service
-use the `REST_PATH` build argument.
+By default, the `Dockerfile` will build the OSCAL Viewer from source unless the `VIEWER_PATH` build argument is
+provided and will build the OSCAL REST Service from source unless the `REST_PATH` build argument is provided.
+When building from source, the `develop` branch is used by default.
 
-For example:
-```
-docker build --build-arg VIEWER_PATH=./build --build-arg REST_PATH=./different_file.jar --tag oscal-editor-all-in-one .
-```
+For example, to specify a locally-built Viewer and REST service in local directory,
 
-To specify a different GitHub repo or branch for the OSCAL viewer use the `OSCAL_REACT_GIT_REPO` and `OSCAL_REACT_GIT_BRANCH`.
-
-For example:
-```
-docker build --build-arg OSCAL_REACT_GIT_REPO=https://github.com/MyOrg/oscal-react-library  --build-arg OSCAL_REACT_GIT_BRANCH=some-feature-branch --tag oscal-editor-all-in-one .
+```bash
+docker build --build-arg VIEWER_PATH=./oscal-viewer --build-arg REST_PATH=./oscal-rest.jar --tag oscal-editor-all-in-one .
 ```
 
-Access other than read requires a [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-with [appropriate package permissions](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#visibility-and-access-permissions-for-container-images).
-It is recommended to save this PAT as an environment variable.
+To build from source but to use a branch other than `develop`, you can use the `OSCAL_REACT_GIT_BRANCH` to change
+the branch of for OSCAL Viewer and `OSCAL_REST_SERVICE_GIT_BRANCH` to change the branch for the OSCAL REST service.
 
-Using this PAT, log into the registry by running:
+For example, to use the `feature/foo` branch of the Viewer and `feature/bar` of the REST service:
+
+```bash
+docker build --build-arg OSCAL_REACT_GIT_BRANCH=feature/foo --build-arg OSCAL_REST_SERVICE_GIT_BRANCH=feature/bar --tag oscal-editor-all-in-one .
 ```
-echo ${PAT} | docker login ghcr.io -u GITHUB_USERNAME --password-stdin
-```
+
+For each project, you may also specify `OSCAL_REACT_GIT_REPO` and `OSCAL_REST_SERVICE_GIT_REPO` if you wish to build
+from using using branches on a fork of the repository.
+
+### Building Required Resources
+
+If you wish to build the OSCAL Viewer or REST service yourself, you may do so following the documentation from the respective
+repositories and then passing the path to the build artifacts using the `VIEWER_PATH` and/or `REST_PATH` build arguments. In
+most cases this is not necessary as the `_GIT_BRANCH` build arguments support both branches and tags. 
 
 ## Testing
 

--- a/all-in-one/packages_pull.sh
+++ b/all-in-one/packages_pull.sh
@@ -36,15 +36,6 @@ assert-required-commands() (
   exit "$missing"
 )
 
-unauthenticated-v3-api-request() (
-  local url="$1"
-
-  curl \
-    -sL \
-    -H "Accept: application/vnd.github.v3+json" \
-    "$url"
-)
-
 authenticated-v3-api-request() (
   local url="$1"
   local token="$2"
@@ -67,14 +58,7 @@ authenticated-pkg-api-request() (
 )
 
 get-viewer-zip() (
-  local request_url="https://api.github.com/repos/EasyDynamics/oscal-react-library/releases/latest"
-  local zip_url
-
-  zip_url="$(unauthenticated-v3-api-request "$request_url" | jq --raw-output '.assets[] | select(.name=="oscal-viewer.zip") | .browser_download_url' )"
-  if [ "$?" -ne 0 ] || [ -z "$zip_url" ] ; then
-    echo "!!! Unable to get download url for OSCAL React Viewer"
-    exit 1
-  fi
+  local zip_url="https://github.com/EasyDynamics/oscal-react-library/releases/latest/download/oscal-viewer.zip"
 
   local output="./viewer.zip"
   if ! curl -sL -o "$output" "$zip_url"; then
@@ -153,7 +137,6 @@ main() (
   fi
 
   unzip -qo ./viewer.zip -d ./viewer
-  cp -r viewer/build .
 
   echo "==> Fetching OSCAL REST Service JAR file"
 


### PR DESCRIPTION
This makes `oscal-rest-service` work almost identically to the Viewer
application as far as the build process goes. A separate stage builds
the REST service which is then copied into the final stage. This limits
the size and amount of tooling in the final stage.

Some general refactoring was done as well. The versions of images were
parameterized. Since don't care about the Node version really, we just
pull the latest LTS so we don't have to worry about specific versions.
For the Java container itself, we now pull `-slim-bullseye` instead of
`-jre-slim` as the `-jre`-related containers are not present for newer
versions of Java and the base image after Java 11 changed to Oracle
Linux. We _do not_ change the default version of Java in use as part of
this PR, we just parameterize it.

The names of files were also changed around. Having a directory just
named `build` becomes a little confusing when there are now two built
artifacts, so at least in the final image, they're given more specific
names.

The documentation on how to build the container is significantly
reworded.

~The CI/CD pipeline has also been modified to actually ensure we use all
artifacts that we download. We previously would always rebuild the
viewer (even though we had downloaded it). I am not sure which
behavior we prefer, a specific release or rebuilding.~ (JK that breaks)

`package_pull.sh` also got cleaned up a bit to make downloading the
viewer slightly simpler.

All things considered, if you're familiar with building based on custom
branches of `oscal-react-library`, this should just work the way you
expect but also for `oscal-rest-service` with additional build args.

Closes #17
