### PR TITLE
Update Invalid Docker Hub Login Credentials from Workflow

### DIFF
--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -128,8 +128,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/dockerhub-description@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
           repository: easydynamics/oscal-editor-all-in-one
           short-description: A back-end service and web-based UI for the OSCAL Editor.
           readme-filepath: all-in-one/README.md

--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -128,6 +128,8 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/dockerhub-description@v3
         with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
           repository: easydynamics/oscal-editor-all-in-one
           short-description: A back-end service and web-based UI for the OSCAL Editor.
           readme-filepath: all-in-one/README.md


### PR DESCRIPTION
`container-test-deploy.yml` is failing at the ` Update Docker Hub Short-Description & Overview` step, stating the username is "missing". Within this step, the username is specified as `username: ${{ secrets.DOCKERHUB_USERNAME }}`. Earlier in the workflow, Docker Hub is signed into with `secrets.DOCKER_USERNAME`, which excludes "HUB" and should be used to login to Docker Hub. The sign-in issue would arise with the password line below for the same reason as well.

Fixes #85 