### PR TITLE
Make end-to-end Tests for Editable Textfield

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -42,7 +42,7 @@ Example:
 docker run -p 8080:8080 -v "$(pwd)"/oscal-content:/app/oscal-content ghcr.io/easydynamics/oscal-editor-all-in-one
 ```
 
-The container will run both the OSCAL Viewer and REST Service on startup. The OSCAL Viewer is available at the port specified in the run command, eg. `http://localhost:8080`, and HTTP requests can be made to the REST Service at the same port following the [OSCAL Rest API specification.](https://github.com/EasyDynamics/oscal-rest), eg. http://localhost:8080/oscal/v1/ssps/cff8385f-108e-40a5-8f7a-82f3dc0eaba8
+The container will run both the OSCAL Viewer and REST Service on startup. The OSCAL Viewer is available at the port specified in the run command, eg. `http://localhost:8080`, and HTTP requests can be made to the REST Service at the same port following the [OSCAL Rest API specification.](https://github.com/EasyDynamics/oscal-rest), eg. `http://localhost:8080/oscal/v1/ssps/cff8385f-108e-40a5-8f7a-82f3dc0eaba8`
 
 ### Manually Configuring Directory Paths
 
@@ -57,7 +57,7 @@ The environment variables can be set using the `-e` flag of the `docker run` com
 
 ## Building & Testing
 
-For information on locally building and testing, please see [BUILDING-TESTING.md](./BUILDING-TESTING.md).
+For information on locally building and testing, please see [BUILDING-TESTING.md](https://github.com/EasyDynamics/oscal-editor-deployment/blob/main/all-in-one/BUILDING-TESTING.md).
 
 ## Reporting Issues
 

--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -7,6 +7,7 @@ Simple Docker deployment of the back-end services and web-based user interface f
 The Docker image is hosted on [Docker Hub](https://hub.docker.com/r/easydynamics/oscal-editor-all-in-one) and the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
 
 You can pull the image by running:
+
 ```
 docker pull ghcr.io/easydynamics/oscal-editor-all-in-one
 ```
@@ -25,7 +26,8 @@ oscal-content/
 ├── profiles
 └── system-security-plans
 ```
-Each of the four sub-directories should contain the **JSON** OSCAL files of their respective schemas.  There are tools available to convert other OSCAL formats to JSON such as [NIST's XSL converters](https://github.com/usnistgov/OSCAL/tree/main/json/convert).
+
+Each of the four sub-directories should contain the **JSON** OSCAL files of their respective schemas. There are tools available to convert other OSCAL formats to JSON such as [NIST's XSL converters](https://github.com/usnistgov/OSCAL/tree/main/json/convert).
 
 Example OSCAL content can be downloaded from [Easy Dynamics' demo OSCAL content repo](https://github.com/EasyDynamics/oscal-demo-content). To clone the content, run:
 
@@ -37,7 +39,8 @@ git clone https://github.com/EasyDynamics/oscal-demo-content oscal-content
 
 To run the docker image, run `docker run` with the `-p` flag specifying the port to map and the `-v` flag specifying the path of the OSCAL content directory.
 
-Example: 
+Example:
+
 ```
 docker run -p 8080:8080 -v "$(pwd)"/oscal-content:/app/oscal-content ghcr.io/easydynamics/oscal-editor-all-in-one
 ```
@@ -47,6 +50,7 @@ The container will run both the OSCAL Viewer and REST Service on startup. The OS
 ### Manually Configuring Directory Paths
 
 If needed, the directory and sub-directory paths of the OSCAL content directory can also be manually configured by overwriting these environment variables in the container:
+
 - `PERSISTENCE_FILE_PARENT_PATH`
 - `PERSISTENCE_FILE_CATALOGS_PATH`
 - `PERSISTENCE_FILE_COMPONENT_DEFINITIONS_PATH`

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
@@ -57,7 +57,7 @@ describe('Test Editing Existing SSP Impl Req Statement', () => {
     const PARAM_VALUE_ORIG =
       "all staff and contractors within the organization";
     const PARAM_VALUE_NEW = "some other param value";
-    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.contains("button", COMPONENT_NAME).click();
     cy.get(
       `[aria-label="edit-bycomponent-795533ab-9427-4abe-820f-0b571bacfe6d-statement-au-1_smt.a"]`
@@ -85,7 +85,7 @@ describe("Test Editing New SSP Impl Req Statement", () => {
   it("Successfully Edits New SSP Impl Req Statement", () => {
     const COMPONENT_NAME = "Logging Server";
     const PARAM_VALUE_NEW =
-      "some new param value" + cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+      "some new param value" + cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.contains("button", COMPONENT_NAME).click();
     cy.get(
       `[aria-label="edit-bycomponent-e00acdcf-911b-437d-a42f-b0b558cc4f03-statement-au-1_smt.a"]`
@@ -113,7 +113,7 @@ describe("Test Adding New SSP Impl Req", () => {
   it("Successfully Adds New SSP Impl Req", () => {
     const CONTROL_ID = "AU-2";
     const CONTROL_NAME = "Audit Events";
-    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.contains("button", "Add Control Implementation").click();
     cy.contains("Select Control").click({ force: true }).type(CONTROL_ID);
     cy.contains(`${CONTROL_ID} ${CONTROL_NAME}`).click();
@@ -138,23 +138,23 @@ describe("Test Editing Title Using Enter key", () => {
   });
 
   it("Successfully Edits Title with Enter", () => {
-    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
-      .click()
-      .clear()
-      .type("A Different SSP{enter}");
+    .click()
+    .clear()
+    .type("A Different SSP{enter}");
     cy.contains("A Different SSP").should("be.visible");
   });
-
+  
   it("Successfully keeps title on Enter press", () => {
-    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
       .click()
       .clear()
       .type("{enter}");
-    cy.contains(SSP_TITLE_ORIG).should("be.visible");
+    cy.contains(SSP_TITLE_ORIG);
   });
 });
 
@@ -168,7 +168,7 @@ describe("Cancel on ESC Keypress", () => {
   });
 
   it("ESC key cancels any changes", () => {
-    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
 
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
@@ -181,7 +181,7 @@ describe("Cancel on ESC Keypress", () => {
       .should("have.value", SSP_TITLE_ORIG);
   });
   it("Enter key changes textfield value", () => {
-    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
 
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
@@ -130,7 +130,7 @@ describe("Test 'Enter' Key Keypress in Textfields will", () => {
   });
 
   it("Save All Changes Made to Edited Textfield", () => {
-    cy.navToSspViewer(SSP_TITLE_ORIG);
+    cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
     .click()
@@ -140,7 +140,7 @@ describe("Test 'Enter' Key Keypress in Textfields will", () => {
   });
 
   it("Preserve Textfield Value if its the Only Key Pressed", () => {
-    cy.navToSspViewer(SSP_TITLE_ORIG);
+    cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
       .click()
@@ -160,7 +160,7 @@ describe("Test 'ESC' Key Keypress in Textfields will", () => {
   });
 
   it("Cancel Edit State and Revert Any Changes to Previous Value", () => {
-    cy.navToSspViewer(SSP_TITLE_ORIG);
+    cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
 
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
@@ -173,7 +173,7 @@ describe("Test 'ESC' Key Keypress in Textfields will", () => {
       .should("have.value", SSP_TITLE_ORIG);
   });
   it("Cancel Edit State if its the Only Key Pressed", () => {
-    cy.navToSspViewer(SSP_TITLE_ORIG);
+    cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
 
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
@@ -1,12 +1,12 @@
-const SSP_TITLE_ORIG = 'Enterprise Logging and Auditing System Security Plan'
-const COMP_DEF_TITLE_ORIG = 'Test Component Definition'
+const SSP_TITLE_ORIG = "Enterprise Logging and Auditing System Security Plan";
+const COMP_DEF_TITLE_ORIG = "Test Component Definition";
 
-describe('Test Editing System Security Plan Title', () => {
+describe("Test Editing System Security Plan Title", () => {
   // Store current SSP and reset after test
-  let origSspJson
+  let origSspJson;
   before(() => {
-    cy.getTestSspJson().then(result => origSspJson = result)
-  })
+    cy.getTestSspJson().then((result) => (origSspJson = result));
+  });
   after(() => {
     cy.setTestSspJson(origSspJson)
   })
@@ -22,10 +22,10 @@ describe('Test Editing System Security Plan Title', () => {
 
 describe('Test Editing System Security Plan Source', () => {
   // Store current SSP and reset after test
-  let origSspJson
+  let origSspJson;
   before(() => {
-    cy.getTestSspJson().then(result => origSspJson = result)
-  })
+    cy.getTestSspJson().then((result) => (origSspJson = result));
+  });
   after(() => {
     cy.setTestSspJson(origSspJson)
   })
@@ -43,78 +43,154 @@ describe('Test Editing System Security Plan Source', () => {
 
 describe('Test Editing Existing SSP Impl Req Statement', () => {
   // Store current SSP and reset after test
-  let origSspJson
+  let origSspJson;
   before(() => {
-    cy.getTestSspJson().then(result => origSspJson = result)
-  })
+    cy.getTestSspJson().then((result) => (origSspJson = result));
+  });
   after(() => {
-    cy.setTestSspJson(origSspJson)
-  })
+    cy.setTestSspJson(origSspJson);
+  });
 
-  it('Successfully Edits Existing SSP Impl Req Statement', () => {
-    const COMPONENT_NAME = 'Enterprise Logging, Monitoring, and Alerting Policy'
-    const PARAM_VALUE_ORIG = 'all staff and contractors within the organization'
-    const PARAM_VALUE_NEW = 'some other param value'
-    cy.navToSspViewer(SSP_TITLE_ORIG);
-    cy.contains('button', COMPONENT_NAME).click()
-    cy.get(`[aria-label="edit-bycomponent-795533ab-9427-4abe-820f-0b571bacfe6d-statement-au-1_smt.a"]`).click()
-    cy.getInputByLabel('au-1_prm_1').clear().type(PARAM_VALUE_NEW)
-    cy.intercept('GET', '/oscal/v1/system-security-plans/*').as('getSsp')
-    cy.get(`[aria-label="save-au-1_smt.a"]`).click({force: true})
-    cy.wait('@getSsp')
+  it("Successfully Edits Existing SSP Impl Req Statement", () => {
+    const COMPONENT_NAME =
+      "Enterprise Logging, Monitoring, and Alerting Policy";
+    const PARAM_VALUE_ORIG =
+      "all staff and contractors within the organization";
+    const PARAM_VALUE_NEW = "some other param value";
+    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.contains("button", COMPONENT_NAME).click();
+    cy.get(
+      `[aria-label="edit-bycomponent-795533ab-9427-4abe-820f-0b571bacfe6d-statement-au-1_smt.a"]`
+    ).click();
+    cy.getInputByLabel("au-1_prm_1").clear().type(PARAM_VALUE_NEW);
+    cy.intercept("GET", "/oscal/v1/system-security-plans/*").as("getSsp");
+    cy.get(`[aria-label="save-au-1_smt.a"]`).click({ force: true });
+    cy.wait("@getSsp");
     // Verify updated value
-    cy.contains('button', COMPONENT_NAME).click()
-    cy.contains(PARAM_VALUE_NEW).should('be.visible')
-  })
-})
+    cy.contains("button", COMPONENT_NAME).click();
+    cy.contains(PARAM_VALUE_NEW).should("be.visible");
+  });
+});
 
-describe('Test Editing New SSP Impl Req Statement', () => {
+describe("Test Editing New SSP Impl Req Statement", () => {
   // Store current SSP and reset after test
-  let origSspJson
+  let origSspJson;
   before(() => {
-    cy.getTestSspJson().then(result => origSspJson = result)
-  })
+    cy.getTestSspJson().then((result) => (origSspJson = result));
+  });
   after(() => {
-    cy.setTestSspJson(origSspJson)
-  })
+    cy.setTestSspJson(origSspJson);
+  });
 
-  it('Successfully Edits New SSP Impl Req Statement', () => {
-    const COMPONENT_NAME = 'Logging Server'
-    const PARAM_VALUE_NEW = 'some new param value'+
-    cy.navToSspViewer(SSP_TITLE_ORIG);
-    cy.contains('button', COMPONENT_NAME).click()
-    cy.get(`[aria-label="edit-bycomponent-e00acdcf-911b-437d-a42f-b0b558cc4f03-statement-au-1_smt.a"]`).click()
-    cy.getInputByLabel('au-1_prm_1').clear().type(PARAM_VALUE_NEW)
-    cy.intercept('GET', '/oscal/v1/system-security-plans/*').as('getSsp')
-    cy.get(`[aria-label="save-au-1_smt.a"]`).click({force: true})
-    cy.wait('@getSsp')
+  it("Successfully Edits New SSP Impl Req Statement", () => {
+    const COMPONENT_NAME = "Logging Server";
+    const PARAM_VALUE_NEW =
+      "some new param value" + cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.contains("button", COMPONENT_NAME).click();
+    cy.get(
+      `[aria-label="edit-bycomponent-e00acdcf-911b-437d-a42f-b0b558cc4f03-statement-au-1_smt.a"]`
+    ).click();
+    cy.getInputByLabel("au-1_prm_1").clear().type(PARAM_VALUE_NEW);
+    cy.intercept("GET", "/oscal/v1/system-security-plans/*").as("getSsp");
+    cy.get(`[aria-label="save-au-1_smt.a"]`).click({ force: true });
+    cy.wait("@getSsp");
     // Verify updated value
-    cy.contains('button', COMPONENT_NAME).click()
-    cy.contains(PARAM_VALUE_NEW).should('be.visible')
-  })
-})
+    cy.contains("button", COMPONENT_NAME).click();
+    cy.contains(PARAM_VALUE_NEW).should("be.visible");
+  });
+});
 
-describe('Test Adding New SSP Impl Req', () => {
+describe("Test Adding New SSP Impl Req", () => {
   // Store current SSP and reset after test
-  let origSspJson
+  let origSspJson;
   before(() => {
-    cy.getTestSspJson().then(result => origSspJson = result)
-  })
+    cy.getTestSspJson().then((result) => (origSspJson = result));
+  });
   after(() => {
-    cy.setTestSspJson(origSspJson)
-  })
+    cy.setTestSspJson(origSspJson);
+  });
 
-  it('Successfully Adds New SSP Impl Req', () => {
-    const CONTROL_ID = 'AU-2'
-    const CONTROL_NAME = 'Audit Events'
-    cy.navToSspViewer(SSP_TITLE_ORIG);
-    cy.contains('button', 'Add Control Implementation').click()
-    cy.contains('Select Control').click({force: true}).type(CONTROL_ID)
-    cy.contains(`${CONTROL_ID} ${CONTROL_NAME}`).click()
-    cy.intercept('GET', '/oscal/v1/system-security-plans/*').as('getSsp')
-    cy.get(`[aria-label="save-system-security-plan-control-implementation"]`).click()
-    cy.wait('@getSsp')
+  it("Successfully Adds New SSP Impl Req", () => {
+    const CONTROL_ID = "AU-2";
+    const CONTROL_NAME = "Audit Events";
+    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.contains("button", "Add Control Implementation").click();
+    cy.contains("Select Control").click({ force: true }).type(CONTROL_ID);
+    cy.contains(`${CONTROL_ID} ${CONTROL_NAME}`).click();
+    cy.intercept("GET", "/oscal/v1/system-security-plans/*").as("getSsp");
+    cy.get(
+      `[aria-label="save-system-security-plan-control-implementation"]`
+    ).click();
+    cy.wait("@getSsp");
     // Verify updated value
-    cy.contains('h2', CONTROL_NAME).should('be.visible')
-  })
-})
+    cy.contains("h2", CONTROL_NAME).should("be.visible");
+  });
+});
+
+describe("Test Editing Title Using Enter key", () => {
+  // Store current SSP and reset after test
+  let origSspJson;
+  before(() => {
+    cy.getTestSspJson().then((result) => (origSspJson = result));
+  });
+  afterEach(() => {
+    cy.setTestSspJson(origSspJson);
+  });
+
+  it("Successfully Edits Title with Enter", () => {
+    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
+    cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
+      .click()
+      .clear()
+      .type("A Different SSP{enter}");
+    cy.contains("A Different SSP").should("be.visible");
+  });
+
+  it("Successfully keeps title on Enter press", () => {
+    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
+    cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
+      .click()
+      .clear()
+      .type("{enter}");
+    cy.contains(SSP_TITLE_ORIG).should("be.visible");
+  });
+});
+
+describe("Cancel on ESC Keypress", () => {
+  let origSspJson;
+  before(() => {
+    cy.getTestSspJson().then((result) => (origSspJson = result));
+  });
+  afterEach(() => {
+    cy.setTestSspJson(origSspJson);
+  });
+
+  it("ESC key cancels any changes", () => {
+    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
+
+    cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
+      .click()
+      .clear()
+      .type("My new title {esc}");
+    cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
+    cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
+      .click()
+      .should("have.value", SSP_TITLE_ORIG);
+  });
+  it("Enter key changes textfield value", () => {
+    cy.navToTestSspRestMode(SSP_TITLE_ORIG);
+    cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
+
+    cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
+      .click()
+      .clear()
+      .type("{esc}");
+    cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
+    cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
+      .click()
+      .should("have.value", SSP_TITLE_ORIG);
+  });
+});

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
@@ -127,7 +127,7 @@ describe("Test Adding New SSP Impl Req", () => {
   });
 });
 
-describe("Test Editing Title Using Enter key", () => {
+describe("Test 'Enter' Key Keypress in Textfields will", () => {
   // Store current SSP and reset after test
   let origSspJson;
   before(() => {
@@ -137,7 +137,7 @@ describe("Test Editing Title Using Enter key", () => {
     cy.setTestSspJson(origSspJson);
   });
 
-  it("Successfully Edits Title with Enter", () => {
+  it("Save All Changes Made to Edited Textfield", () => {
     cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
@@ -146,8 +146,8 @@ describe("Test Editing Title Using Enter key", () => {
     .type("A Different SSP{enter}");
     cy.contains("A Different SSP").should("be.visible");
   });
-  
-  it("Successfully keeps title on Enter press", () => {
+
+  it("Preserve Textfield Value if its the Only Key Pressed", () => {
     cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`)
@@ -158,7 +158,7 @@ describe("Test Editing Title Using Enter key", () => {
   });
 });
 
-describe("Cancel on ESC Keypress", () => {
+describe("Test 'ESC' Key Keypress in Textfields will", () => {
   let origSspJson;
   before(() => {
     cy.getTestSspJson().then((result) => (origSspJson = result));
@@ -167,7 +167,7 @@ describe("Cancel on ESC Keypress", () => {
     cy.setTestSspJson(origSspJson);
   });
 
-  it("ESC key cancels any changes", () => {
+  it("Cancel Edit State and Revert Any Changes to Previous Value", () => {
     cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
 
@@ -180,7 +180,7 @@ describe("Cancel on ESC Keypress", () => {
       .click()
       .should("have.value", SSP_TITLE_ORIG);
   });
-  it("Enter key changes textfield value", () => {
+  it("Cancel Edit State if its the Only Key Pressed", () => {
     cy.navToSspViewer(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click();
 

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Load_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Load_Tests.cy.js
@@ -1,5 +1,5 @@
-const SSP_TITLE_ORIG = 'Enterprise Logging and Auditing System Security Plan'
-const COMP_DEF_TITLE_ORIG = 'Test Component Definition'
+const SSP_TITLE_ORIG = "Enterprise Logging and Auditing System Security Plan";
+const COMP_DEF_TITLE_ORIG = "Test Component Definition";
 
 describe('Test Loading System Security Plans', () => {
   it('Successfully Loads SSPs by REST Mode', () => {
@@ -37,12 +37,20 @@ describe('Test Loading Component Definitions', () => {
   })
 })
 
-describe('Test Loading Wrong Object Type', () => {
-  it('Displays Proper Error on Load of Wrong Object Type', () => {
-    cy.visit(Cypress.env('base_url')) 
-    cy.contains("REST Mode").click()
-    cy.contains('OSCAL Catalog URL').first().should('exist').next().click().clear().type("https://raw.githubusercontent.com/usnistgov/oscal-content/main/examples/ssp/json/ssp-example.json")
-    cy.contains('Reload').click()
-    cy.contains('Yikes').should('be.visible')
-  })
-})
+describe("Test Loading Wrong Object Type", () => {
+  it("Displays Proper Error on Load of Wrong Object Type", () => {
+    cy.visit(Cypress.env("base_url"));
+    cy.contains("REST Mode").click();
+    cy.contains("OSCAL Catalog URL")
+      .first()
+      .should("exist")
+      .next()
+      .click()
+      .clear()
+      .type(
+        "https://raw.githubusercontent.com/usnistgov/oscal-content/main/examples/ssp/json/ssp-example.json"
+      );
+    cy.contains("Reload").click();
+    cy.contains("Yikes").should("be.visible");
+  });
+});


### PR DESCRIPTION
Enter:
Makes sure that any edits save after a Enter key press
Tests the title saves current title if Only Enter is Pressed

ESC:
Tests if ESC key press will cancel any edits made. reverts to original title before edit
Tests text field will remains same if only ESC is pressed.

Also changed to afterEach in each test suite to make sure each test runs with the same default parameters.

Note: When reviewed, may want to combine this cypress test with OSCAL_Edit_Tests.cy.js

Closes the Issue https://github.com/EasyDynamics/oscal-editor-deployment/issues/97