### PR TITLE
Build Docker container and run tests daily

### DIFF
--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -7,6 +7,9 @@ on:
       - 'v*'
   pull_request:
   workflow_dispatch:
+  schedule:
+    # Run daily at 12:15 UTC (08:15 EDT/07:15 EST)
+    - cron: "15 12 * * *"
 
 env:
   IMAGE_NAME: oscal-editor-all-in-one


### PR DESCRIPTION
We run into issues pretty regularly where changes happen in another repo
that don't necessarily get caught by the end-to-end tests for awhile
because we don't open/merge PRs on this repo every day. Ideally, we'd do
something event-based but that takes some effort to do cross-repo and
this is something small that gives us incremental improvement today.
