### PR TITLE
Update file names in `packages_pull.sh` to match `BUILDING-TESTING.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ node_modules
 .settings
 all-in-one/build/
 all-in-one/oscal-content/
-all-in-one/viewer.zip
-all-in-one/viewer
+all-in-one/oscal-viewer.zip
+all-in-one/oscal-viewer
 all-in-one/*.jar

--- a/all-in-one/packages_pull.sh
+++ b/all-in-one/packages_pull.sh
@@ -60,7 +60,7 @@ authenticated-pkg-api-request() (
 get-viewer-zip() (
   local zip_url="https://github.com/EasyDynamics/oscal-react-library/releases/latest/download/oscal-viewer.zip"
 
-  local output="./viewer.zip"
+  local output="./oscal-viewer.zip"
   if ! curl -sL -o "$output" "$zip_url"; then
     echo "!!! Unable to download OSCAL React Viewer ZIP file"
     exit 1
@@ -97,14 +97,14 @@ get-rest-service-jar() (
   fi
 
   local service_jar_url="https://maven.pkg.github.com/EasyDynamics/oscal-rest-service/com.easydynamics/oscal-rest-service-app/$package_version/oscal-rest-service-app-$timestamp.jar"
-  if ! curl -H "Authorization: token $token" -sL -o "./oscal-rest-service.jar" "$service_jar_url"; then
+  if ! curl -H "Authorization: token $token" -sL -o "./oscal-rest.jar" "$service_jar_url"; then
     echo "!!! Unable to download the OSCAL Rest Service .jar file"
     exit 1
   fi
 )
 
 cleanup() (
-  rm -rf ./viewer ./viewer.zip
+  rm -rf ./oscal-viewer ./oscal-viewer.zip
 )
 
 main() (
@@ -136,7 +136,7 @@ main() (
     exit 1
   fi
 
-  unzip -qo ./viewer.zip -d ./viewer
+  unzip -qo ./oscal-viewer.zip -d ./oscal-viewer
 
   echo "==> Fetching OSCAL REST Service JAR file"
 


### PR DESCRIPTION
When following `all-in-one/BUILDING-TESTING.md` and downloading the OSCAL Viewer and REST Service using the `packages_pull.sh` script, the downloaded file names do not follow the names as described in the documentation, specifically what is passed as the `VIEWER_PATH` and the `REST_PATH`. To fix this issue, the names of these files have been updated in the script to what is suggested in the documentation. 

## Testing
A GitHub [PAC](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with the `delete:packages` scope is required to be run with the `packages_pull.sh` script.