### PR TITLE
Standardize test names

### DIFF
--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -8,26 +8,26 @@ const PROFILE_NAVIGATION_V5 =
   "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE";
 const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
 
-describe("Test can navigate to Drawer Components", () => {
-  it("Successfully Loads Catalog Editor", () => {
+describe("Drawer Component", () => {
+  it("loads catalog editor", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
   });
 
-  it("Successfully Loads Component Editor", () => {
+  it("loads component editor", () => {
     cy.navToCdefEditor(MONGODB_NAVIGATION);
     cy.navToCdefEditor(COMPONENT_NAVIGATION);
   });
 
-  it("Successfully Loads Profile Component", () => {
+  it("loads profile component", () => {
     cy.navToProfileEditor(PROFILE_NAVIGATION_V4);
     cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
   });
 
-  it("Successfully Loads SSP Editor", () => {
+  it("loads system security plan editor", () => {
     cy.navToSspEditor(SSP_NAVIGATION);
   });
 
-  it("Successfully Navigates Editors in Random Order", () => {
+  it("navigates editors in random order", () => {
     cy.navToCdefEditor(MONGODB_NAVIGATION);
     cy.navToSspEditor(SSP_NAVIGATION);
     cy.navToProfileEditor(PROFILE_NAVIGATION_V4);
@@ -38,7 +38,7 @@ describe("Test can navigate to Drawer Components", () => {
   });
 });
 
-describe("Test can navigate with REST mode off", () => {
+describe("The Viewer", () => {
   let origSspJson;
   before(() => {
     cy.getTestSspJson().then((result) => (origSspJson = result));
@@ -47,42 +47,35 @@ describe("Test can navigate with REST mode off", () => {
     cy.setTestSspJson(origSspJson);
   });
 
-  it("Successfully Loads Catalog in non REST", () => {
+  it("loads a catalog", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
     cy.contains("REST Mode").click();
     cy.contains("Catalog");
     cy.contains(CATALOG_NAVIGATION);
   });
 
-  it("Successfully Loads Profile Version 4 in non REST", () => {
+  it("loads the v4 profile", () => {
     cy.navToProfileEditor(PROFILE_NAVIGATION_V4);
     cy.contains("REST Mode").click();
     cy.contains("Profile");
     cy.contains(PROFILE_NAVIGATION_V4);
   });
 
-  it("Successfully Loads Profile Version 5 in non REST", () => {
+  it("loads the v5 profile", () => {
     cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
     cy.contains("REST Mode").click();
     cy.contains("Profile");
     cy.contains(PROFILE_NAVIGATION_V4);
   });
 
-  it("Successfully Loads Test Component Definiition in non REST", () => {
+  it("loads a component", () => {
     cy.navToCdefEditor(COMPONENT_NAVIGATION);
     cy.contains("REST Mode").click();
     cy.contains("Component");
     cy.contains(COMPONENT_NAVIGATION);
   });
 
-  it("Successfully Loads MongoDB Editor in non REST", () => {
-    cy.navToCdefEditor(COMPONENT_NAVIGATION);
-    cy.contains("REST Mode").click();
-    cy.contains("Component");
-    cy.contains(COMPONENT_NAVIGATION);
-  });
-
-  it("Successfully Loads SSP in non REST", () => {
+  it("loads a system security plan", () => {
     cy.navToSspEditor(SSP_NAVIGATION);
     cy.contains("REST Mode").click();
     cy.contains("System Security Plan");

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
@@ -1,7 +1,7 @@
 const SSP_TITLE_ORIG = "Enterprise Logging and Auditing System Security Plan";
 const COMP_DEF_TITLE_ORIG = "Test Component Definition";
 
-describe("Test Editing System Security Plan Title", () => {
+describe('Editing the system security plan title', () => {
   // Store current SSP and reset after test
   let origSspJson;
   before(() => {
@@ -11,7 +11,7 @@ describe("Test Editing System Security Plan Title", () => {
     cy.setTestSspJson(origSspJson)
   })
 
-  it('Successfully Edits SSP Title', () => {
+  it('edits the system security plan title', () => {
     cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.get(`[aria-label="edit-system-security-plan-metadata-title"]`).click()
     cy.get(`[data-testid="textField-system-security-plan-metadata-title"]`).click().clear().type('Another SSP')
@@ -20,7 +20,7 @@ describe("Test Editing System Security Plan Title", () => {
   })
 })
 
-describe('Test Editing System Security Plan Source', () => {
+describe('Editing the System Security Plan Source', () => {
   // Store current SSP and reset after test
   let origSspJson;
   before(() => {
@@ -30,7 +30,7 @@ describe('Test Editing System Security Plan Source', () => {
     cy.setTestSspJson(origSspJson)
   })
 
-  it('Successfully Edits SSP Source', () => {
+  it('edits the system security plan source', () => {
     cy.navToSspEditor(SSP_TITLE_ORIG);
     const findKeystroke = Cypress.platform === 'darwin' ? '{meta}f' : '{ctrl}f'
     cy.get('.monaco-editor textarea:first')
@@ -41,7 +41,7 @@ describe('Test Editing System Security Plan Source', () => {
   })
 })
 
-describe('Test Editing Existing SSP Impl Req Statement', () => {
+describe('Editing the existing system security plan impl req statement', () => {
   // Store current SSP and reset after test
   let origSspJson;
   before(() => {
@@ -51,7 +51,7 @@ describe('Test Editing Existing SSP Impl Req Statement', () => {
     cy.setTestSspJson(origSspJson);
   });
 
-  it('Successfully Edits Existing SSP Impl Req Statement', () => {
+  it('edits existing system security plan impl req statement', () => {
     const COMPONENT_NAME = 'Enterprise Logging, Monitoring, and Alerting Policy'
     const PARAM_VALUE_ORIG = 'all staff and contractors within the organization'
     const PARAM_VALUE_NEW = 'some other param value'
@@ -68,7 +68,7 @@ describe('Test Editing Existing SSP Impl Req Statement', () => {
   });
 });
 
-describe("Test Editing New SSP Impl Req Statement", () => {
+describe('Editing the new system security plan impl req statement', () => {
   // Store current SSP and reset after test
   let origSspJson;
   before(() => {
@@ -78,7 +78,7 @@ describe("Test Editing New SSP Impl Req Statement", () => {
     cy.setTestSspJson(origSspJson);
   });
 
-  it('Successfully Edits New SSP Impl Req Statement', () => {
+  it('edits new system security plan impl req statement', () => {
     const COMPONENT_NAME = 'Logging Server'
     const PARAM_VALUE_NEW = 'some new param value'+
     cy.navToSspEditor(SSP_TITLE_ORIG);
@@ -94,7 +94,7 @@ describe("Test Editing New SSP Impl Req Statement", () => {
   });
 });
 
-describe("Test Adding New SSP Impl Req", () => {
+describe('Adding new system security plan impl req', () => {
   // Store current SSP and reset after test
   let origSspJson;
   before(() => {
@@ -104,7 +104,7 @@ describe("Test Adding New SSP Impl Req", () => {
     cy.setTestSspJson(origSspJson);
   });
 
-  it('Successfully Adds New SSP Impl Req', () => {
+  it('adds new system security plan impl req', () => {
     const CONTROL_ID = 'AU-2'
     const CONTROL_NAME = 'Audit Events'
     cy.navToSspEditor(SSP_TITLE_ORIG);

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Load_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Load_Tests.cy.js
@@ -1,14 +1,14 @@
 const SSP_TITLE_ORIG = "Enterprise Logging and Auditing System Security Plan";
 const COMP_DEF_TITLE_ORIG = "Test Component Definition";
 
-describe('Test Loading System Security Plans', () => {
-  it('Successfully Loads SSPs by REST Mode', () => {
+describe('Loading system security plans', () => {
+  it('loads SSPs by REST Mode', () => {
     cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.get(`[aria-label="show code"]`).click()
     cy.scrollTo('bottom')
     cy.contains('This is the control implementation for the system.').should('be.visible')
   })
-  it('Successfully Loads SSPs by URL', () => {
+  it('loads system security plans by URL', () => {
     cy.navToSspEditor(SSP_TITLE_ORIG)
     cy.contains("REST Mode").click()
     cy.contains('OSCAL System Security Plan URL').first().should('exist').next().click().clear().type(Cypress.env('base_url') + "/oscal/v1/system-security-plans/cff8385f-108e-40a5-8f7a-82f3dc0eaba8")
@@ -19,14 +19,14 @@ describe('Test Loading System Security Plans', () => {
   })
 })
 
-describe('Test Loading Component Definitions', () => {
-  it('Successfully Loads Components by REST Mode', () => {
+describe('Loading Component Definitions', () => {
+  it('loads Components by REST Mode', () => {
     cy.navToCdefEditor(COMP_DEF_TITLE_ORIG)
     cy.contains(COMP_DEF_TITLE_ORIG).should('be.visible')
     cy.contains('Test Vendor').should('be.visible')
     cy.scrollTo('bottom')
   })
-  it('Successfully Loads Components by URL', () => {
+  it('loads components by URL', () => {
     cy.navToCdefEditor(COMP_DEF_TITLE_ORIG)
     cy.contains("REST Mode").click()
     cy.contains('OSCAL Component URL').first().should('exist').next().click().clear().type(Cypress.env('base_url') + "/oscal/v1/component-definitions/8223d65f-57a9-4689-8f06-2a975ae2ad72")
@@ -37,8 +37,8 @@ describe('Test Loading Component Definitions', () => {
   })
 })
 
-describe("Test Loading Wrong Object Type", () => {
-  it("Displays Proper Error on Load of Wrong Object Type", () => {
+describe('Loading the wrong object type', () => {
+  it('displays proper error on load of wrong object type', () => {
     cy.visit(Cypress.env("base_url"));
     cy.contains("REST Mode").click();
     cy.contains("OSCAL Catalog URL")


### PR DESCRIPTION
This updates the test names to more accurately follow guidance found on https://jestjs.io/docs/api#describename-fn.

This does not actually edit any functionality, nor does it guarantee the way we do split up the tests with `describe` & `it` is currently perfect other than naming. In fact, we may want to expand https://github.com/EasyDynamics/comply0-private/issues/137 to standardize our cypress tests as well later on. 

All I have done is update the wording to follow the suggested naming conventions.  
