### PR TITLE
Patch broken Docker Hub links

### DIFF
--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -42,7 +42,7 @@ Example:
 docker run -p 8080:8080 -v "$(pwd)"/oscal-content:/app/oscal-content ghcr.io/easydynamics/oscal-editor-all-in-one
 ```
 
-The container will run both the OSCAL Viewer and REST Service on startup. The OSCAL Viewer is available at the port specified in the run command, eg. `http://localhost:8080`, and HTTP requests can be made to the REST Service at the same port following the [OSCAL Rest API specification.](https://github.com/EasyDynamics/oscal-rest), eg. http://localhost:8080/oscal/v1/ssps/cff8385f-108e-40a5-8f7a-82f3dc0eaba8
+The container will run both the OSCAL Viewer and REST Service on startup. The OSCAL Viewer is available at the port specified in the run command, eg. `http://localhost:8080`, and HTTP requests can be made to the REST Service at the same port following the [OSCAL Rest API specification.](https://github.com/EasyDynamics/oscal-rest), eg. `http://localhost:8080/oscal/v1/ssps/cff8385f-108e-40a5-8f7a-82f3dc0eaba8`
 
 ### Manually Configuring Directory Paths
 
@@ -57,7 +57,7 @@ The environment variables can be set using the `-e` flag of the `docker run` com
 
 ## Building & Testing
 
-For information on locally building and testing, please see [BUILDING-TESTING.md](./BUILDING-TESTING.md).
+For information on locally building and testing, please see [BUILDING-TESTING.md](https://github.com/EasyDynamics/oscal-editor-deployment/blob/main/all-in-one/BUILDING-TESTING.md).
 
 ## Reporting Issues
 

--- a/all-in-one/README.md
+++ b/all-in-one/README.md
@@ -7,6 +7,7 @@ Simple Docker deployment of the back-end services and web-based user interface f
 The Docker image is hosted on [Docker Hub](https://hub.docker.com/r/easydynamics/oscal-editor-all-in-one) and the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry).
 
 You can pull the image by running:
+
 ```
 docker pull ghcr.io/easydynamics/oscal-editor-all-in-one
 ```
@@ -25,7 +26,8 @@ oscal-content/
 ├── profiles
 └── system-security-plans
 ```
-Each of the four sub-directories should contain the **JSON** OSCAL files of their respective schemas.  There are tools available to convert other OSCAL formats to JSON such as [NIST's XSL converters](https://github.com/usnistgov/OSCAL/tree/main/json/convert).
+
+Each of the four sub-directories should contain the **JSON** OSCAL files of their respective schemas. There are tools available to convert other OSCAL formats to JSON such as [NIST's XSL converters](https://github.com/usnistgov/OSCAL/tree/main/json/convert).
 
 Example OSCAL content can be downloaded from [Easy Dynamics' demo OSCAL content repo](https://github.com/EasyDynamics/oscal-demo-content). To clone the content, run:
 
@@ -37,7 +39,8 @@ git clone https://github.com/EasyDynamics/oscal-demo-content oscal-content
 
 To run the docker image, run `docker run` with the `-p` flag specifying the port to map and the `-v` flag specifying the path of the OSCAL content directory.
 
-Example: 
+Example:
+
 ```
 docker run -p 8080:8080 -v "$(pwd)"/oscal-content:/app/oscal-content ghcr.io/easydynamics/oscal-editor-all-in-one
 ```
@@ -47,6 +50,7 @@ The container will run both the OSCAL Viewer and REST Service on startup. The OS
 ### Manually Configuring Directory Paths
 
 If needed, the directory and sub-directory paths of the OSCAL content directory can also be manually configured by overwriting these environment variables in the container:
+
 - `PERSISTENCE_FILE_PARENT_PATH`
 - `PERSISTENCE_FILE_CATALOGS_PATH`
 - `PERSISTENCE_FILE_COMPONENT_DEFINITIONS_PATH`


### PR DESCRIPTION
After working to get our `all-in-one/README.md` to show on Docker Hub, it appears a couple of our links are broken, producing 404 errors.

Resolves #85