### PR TITLE
Editor navigation by URLS e2e test

### DIFF
--- a/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
@@ -41,9 +41,11 @@ const NAVIGATION = [
   },
 ];
 describe("Test that the ", () => {
-  it.each(NAVIGATION)(`%s loads by url`, (editor, title, relativeURL) => {
-    cy.visit(`${Cypress.env("base_url")}${relativeURL}`);
-    cy.waitForLoad();
-    cy.contains(`${title}`);
+  NAVIGATION.forEach((element) => {
+    it(`${element.editor} Editor loads by URL`, () => {
+      cy.visit(`${Cypress.env("base_url")}${element.relativeURL}`);
+      cy.waitForLoad();
+      cy.contains(element.title);
+    });
   });
 });

--- a/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
@@ -1,0 +1,95 @@
+const CATALOG_NAVIGATION =
+  "NIST Special Publication 800-53 Revision 5: Security and Privacy Controls for Federal Information Systems and Organizations";
+const CATALOG_URL_NAV =
+  "http://localhost:8080/catalog/613fca2d-704a-42e7-8e2b-b206fb92b456";
+
+const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
+const MONGODB_URL_NAV =
+  "http://localhost:8080/component-definition/a7ba800c-a432-44cd-9075-0862cd66da6b";
+
+const COMPONENT_NAVIGATION = "Test Component Definition";
+const COMPONENT_URL_NAV =
+  "http://localhost:8080/component-definition/8223d65f-57a9-4689-8f06-2a975ae2ad72";
+
+const PROFILE_NAVIGATION_V4 =
+  "NIST Special Publication 800-53 Revision 4 MODERATE IMPACT BASELINE";
+const PROFILE_V4_URL =
+  "http://localhost:8080/profile/8b3beca1-fcdc-43e0-aebb-ffc0a080c486";
+
+const PROFILE_NAVIGATION_V5 =
+  "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE";
+const PROFILE_V5_URL =
+  "http://localhost:8080/profile/1019f424-1556-4aa3-9df3-337b97c2c856";
+
+const SSP_NAVIGATION = "Enterprise Logging and Auditing System Security Plan";
+const SSP_URL_NAV =
+  "http://localhost:8080/system-security-plan/cff8385f-108e-40a5-8f7a-82f3dc0eaba8";
+
+describe("The use URLs to navigate", () => {
+  describe(" from SSP Editor to", () => {
+    before(() => {
+      cy.navToSspEditor(SSP_NAVIGATION);
+    });
+    afterEach(() => {
+      cy.navToSspEditor(SSP_NAVIGATION);
+      cy.contains(SSP_NAVIGATION);
+    });
+    it("Catalog Viewer", () => {
+      cy.visit(CATALOG_URL_NAV);
+      cy.contains(CATALOG_NAVIGATION);
+    });
+    it("MongoDB Component Viewer", () => {
+      cy.visit(MONGODB_URL_NAV);
+      cy.contains(MONGODB_NAVIGATION);
+    });
+    it("Profile Version 4 Viewer", () => {
+      cy.visit(PROFILE_V4_URL);
+      cy.contains(PROFILE_NAVIGATION_V4);
+    });
+    it("MongoDB Component Viewer", () => {
+      cy.visit(PROFILE_V5_URL);
+      cy.contains(PROFILE_NAVIGATION_V5);
+    });
+  });
+  it("from Catalog to SSP", () => {
+    cy.navToCatalogEditor(CATALOG_NAVIGATION);
+    cy.visit(SSP_URL_NAV);
+    cy.contains(SSP_NAVIGATION);
+  });
+
+});
+
+it("Navigates to Editors by URLs in Random order", () => {
+    cy.navToSspEditor(SSP_NAVIGATION);
+
+    cy.visit(SSP_URL_NAV);
+    cy.contains(SSP_NAVIGATION);
+    
+    cy.visit(PROFILE_V5_URL);
+    cy.contains(PROFILE_NAVIGATION_V5);
+
+    cy.visit(PROFILE_V4_URL);
+    cy.contains(PROFILE_NAVIGATION_V4);
+
+    cy.visit(MONGODB_URL_NAV);
+    cy.contains(MONGODB_NAVIGATION);
+
+    cy.visit(CATALOG_URL_NAV);
+    cy.contains(CATALOG_NAVIGATION);
+
+    cy.visit(PROFILE_V4_URL);
+    cy.contains(PROFILE_NAVIGATION_V4);
+
+    cy.visit(SSP_URL_NAV);
+    cy.contains(SSP_NAVIGATION);
+
+    cy.visit(PROFILE_V5_URL);
+    cy.contains(PROFILE_NAVIGATION_V5);
+
+    cy.visit(MONGODB_URL_NAV);
+    cy.contains(MONGODB_NAVIGATION);
+
+    cy.visit(CATALOG_URL_NAV);
+    cy.contains(CATALOG_NAVIGATION);
+
+  });

--- a/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
@@ -41,11 +41,9 @@ const NAVIGATION = [
   },
 ];
 describe("Test that the ", () => {
-  NAVIGATION.forEach((element) => {
-    it(`${element.editor} Editor loads by URL`, () => {
-      cy.visit(`${Cypress.env("base_url")}${element.relativeURL}`);
-      cy.waitForLoad();
-      cy.contains(element.title);
-    });
+  it.each(NAVIGATION)(`%s loads by url`, (editor, title, relativeURL) => {
+    cy.visit(`${Cypress.env("base_url")}${relativeURL}`);
+    cy.waitForLoad();
+    cy.contains(`${title}`);
   });
 });

--- a/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
@@ -1,95 +1,85 @@
 const CATALOG_NAVIGATION =
   "NIST Special Publication 800-53 Revision 5: Security and Privacy Controls for Federal Information Systems and Organizations";
-const CATALOG_URL_NAV =
-  "http://localhost:8080/catalog/613fca2d-704a-42e7-8e2b-b206fb92b456";
+const CATALOG_URL_NAV = "/catalog/613fca2d-704a-42e7-8e2b-b206fb92b456";
 
 const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
 const MONGODB_URL_NAV =
-  "http://localhost:8080/component-definition/a7ba800c-a432-44cd-9075-0862cd66da6b";
+  "/component-definition/a7ba800c-a432-44cd-9075-0862cd66da6b";
 
 const COMPONENT_NAVIGATION = "Test Component Definition";
 const COMPONENT_URL_NAV =
-  "http://localhost:8080/component-definition/8223d65f-57a9-4689-8f06-2a975ae2ad72";
+  "/component-definition/8223d65f-57a9-4689-8f06-2a975ae2ad72";
 
 const PROFILE_NAVIGATION_V4 =
   "NIST Special Publication 800-53 Revision 4 MODERATE IMPACT BASELINE";
-const PROFILE_V4_URL =
-  "http://localhost:8080/profile/8b3beca1-fcdc-43e0-aebb-ffc0a080c486";
+const PROFILE_V4_URL = "/profile/8b3beca1-fcdc-43e0-aebb-ffc0a080c486";
 
 const PROFILE_NAVIGATION_V5 =
   "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE";
-const PROFILE_V5_URL =
-  "http://localhost:8080/profile/1019f424-1556-4aa3-9df3-337b97c2c856";
+const PROFILE_V5_URL = "/profile/1019f424-1556-4aa3-9df3-337b97c2c856";
 
 const SSP_NAVIGATION = "Enterprise Logging and Auditing System Security Plan";
 const SSP_URL_NAV =
-  "http://localhost:8080/system-security-plan/cff8385f-108e-40a5-8f7a-82f3dc0eaba8";
+  "/system-security-plan/cff8385f-108e-40a5-8f7a-82f3dc0eaba8";
 
 describe("The use URLs to navigate", () => {
-  describe(" from SSP Editor to", () => {
-    before(() => {
-      cy.navToSspEditor(SSP_NAVIGATION);
-    });
-    afterEach(() => {
-      cy.navToSspEditor(SSP_NAVIGATION);
-      cy.contains(SSP_NAVIGATION);
-    });
+  describe("from SSP Editor to", () => {
     it("Catalog Viewer", () => {
-      cy.visit(CATALOG_URL_NAV);
+      cy.visit(Cypress.env("base_url") + CATALOG_URL_NAV);
       cy.contains(CATALOG_NAVIGATION);
     });
     it("MongoDB Component Viewer", () => {
-      cy.visit(MONGODB_URL_NAV);
+      cy.visit(Cypress.env("base_url") + MONGODB_URL_NAV);
       cy.contains(MONGODB_NAVIGATION);
     });
     it("Profile Version 4 Viewer", () => {
-      cy.visit(PROFILE_V4_URL);
+      cy.visit(Cypress.env("base_url") + PROFILE_V4_URL);
       cy.contains(PROFILE_NAVIGATION_V4);
     });
     it("MongoDB Component Viewer", () => {
-      cy.visit(PROFILE_V5_URL);
+      cy.visit(Cypress.env("base_url") + PROFILE_V5_URL);
       cy.contains(PROFILE_NAVIGATION_V5);
     });
   });
   it("from Catalog to SSP", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
-    cy.visit(SSP_URL_NAV);
+    cy.visit(Cypress.env("base_url") + SSP_URL_NAV);
     cy.contains(SSP_NAVIGATION);
   });
-
 });
 
-it("Navigates to Editors by URLs in Random order", () => {
+describe("The use URLs to navigate", () => {
+  it("Navigates to Editors by URLs in Random order", () => {
     cy.navToSspEditor(SSP_NAVIGATION);
 
-    cy.visit(SSP_URL_NAV);
-    cy.contains(SSP_NAVIGATION);
-    
-    cy.visit(PROFILE_V5_URL);
-    cy.contains(PROFILE_NAVIGATION_V5);
-
-    cy.visit(PROFILE_V4_URL);
-    cy.contains(PROFILE_NAVIGATION_V4);
-
-    cy.visit(MONGODB_URL_NAV);
-    cy.contains(MONGODB_NAVIGATION);
-
-    cy.visit(CATALOG_URL_NAV);
-    cy.contains(CATALOG_NAVIGATION);
-
-    cy.visit(PROFILE_V4_URL);
-    cy.contains(PROFILE_NAVIGATION_V4);
-
-    cy.visit(SSP_URL_NAV);
+    cy.visit(Cypress.env("base_url") + SSP_URL_NAV);
     cy.contains(SSP_NAVIGATION);
 
-    cy.visit(PROFILE_V5_URL);
+    cy.visit(Cypress.env("base_url") + PROFILE_V5_URL);
     cy.contains(PROFILE_NAVIGATION_V5);
 
-    cy.visit(MONGODB_URL_NAV);
+    cy.visit(Cypress.env("base_url") + PROFILE_V4_URL);
+    cy.contains(PROFILE_NAVIGATION_V4);
+
+    cy.visit(Cypress.env("base_url") + MONGODB_URL_NAV);
     cy.contains(MONGODB_NAVIGATION);
 
-    cy.visit(CATALOG_URL_NAV);
+    cy.visit(Cypress.env("base_url") + CATALOG_URL_NAV);
     cy.contains(CATALOG_NAVIGATION);
 
+    cy.visit(Cypress.env("base_url") + PROFILE_V4_URL);
+    cy.contains(PROFILE_NAVIGATION_V4);
+
+    cy.visit(Cypress.env("base_url") + SSP_URL_NAV);
+    cy.contains(SSP_NAVIGATION);
+
+    cy.visit(Cypress.env("base_url") + PROFILE_V5_URL);
+    cy.contains(PROFILE_NAVIGATION_V5);
+
+    cy.visit(Cypress.env("base_url") + MONGODB_URL_NAV);
+    cy.contains(MONGODB_NAVIGATION);
+
+    cy.visit(Cypress.env("base_url") + CATALOG_URL_NAV);
+    cy.contains(CATALOG_NAVIGATION);
   });
+});

--- a/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
@@ -34,10 +34,11 @@ const NAVIGATION = [
     relativeURL: "/system-security-plan/cff8385f-108e-40a5-8f7a-82f3dc0eaba8",
   },
 ];
-describe("Test navigation by URLs route to", () => {
-  it("each of the editors pages", () => {
+describe("The Editor", () => {
+  it("Loads the correct pages by url", () => {
     cy.wrap(NAVIGATION).each((element) => {
       cy.visit(`${Cypress.env("base_url")}${element.relativeURL}`);
+      cy.waitForLoad();
       cy.contains(element.title);
     });
   });

--- a/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
@@ -1,85 +1,44 @@
-const CATALOG_NAVIGATION =
-  "NIST Special Publication 800-53 Revision 5: Security and Privacy Controls for Federal Information Systems and Organizations";
-const CATALOG_URL_NAV = "/catalog/613fca2d-704a-42e7-8e2b-b206fb92b456";
+const NAVIGATION = [
+  {
+    editor: "Catalog",
+    title:
+      "NIST Special Publication 800-53 Revision 5: Security and Privacy Controls for Federal Information Systems and Organizations",
+    relativeURL: "/catalog/613fca2d-704a-42e7-8e2b-b206fb92b456",
+  },
+  {
+    editor: "MongoDB",
+    title: "MongoDB Component Definition Example",
+    relativeURL: "/component-definition/a7ba800c-a432-44cd-9075-0862cd66da6b",
+  },
+  {
+    editor: "Test Component",
+    title: "Test Component Definition",
+    relativeURL: "/component-definition/8223d65f-57a9-4689-8f06-2a975ae2ad72",
+  },
+  {
+    editor: "Profile V4",
+    title:
+      "NIST Special Publication 800-53 Revision 4 MODERATE IMPACT BASELINE",
 
-const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
-const MONGODB_URL_NAV =
-  "/component-definition/a7ba800c-a432-44cd-9075-0862cd66da6b";
-
-const COMPONENT_NAVIGATION = "Test Component Definition";
-const COMPONENT_URL_NAV =
-  "/component-definition/8223d65f-57a9-4689-8f06-2a975ae2ad72";
-
-const PROFILE_NAVIGATION_V4 =
-  "NIST Special Publication 800-53 Revision 4 MODERATE IMPACT BASELINE";
-const PROFILE_V4_URL = "/profile/8b3beca1-fcdc-43e0-aebb-ffc0a080c486";
-
-const PROFILE_NAVIGATION_V5 =
-  "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE";
-const PROFILE_V5_URL = "/profile/1019f424-1556-4aa3-9df3-337b97c2c856";
-
-const SSP_NAVIGATION = "Enterprise Logging and Auditing System Security Plan";
-const SSP_URL_NAV =
-  "/system-security-plan/cff8385f-108e-40a5-8f7a-82f3dc0eaba8";
-
-describe("The use URLs to navigate", () => {
-  describe("from SSP Editor to", () => {
-    it("Catalog Viewer", () => {
-      cy.visit(Cypress.env("base_url") + CATALOG_URL_NAV);
-      cy.contains(CATALOG_NAVIGATION);
+    relativeURL: "/profile/8b3beca1-fcdc-43e0-aebb-ffc0a080c486",
+  },
+  {
+    editor: "Profile V5",
+    title:
+      "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE",
+    relativeURL: "/profile/1019f424-1556-4aa3-9df3-337b97c2c856",
+  },
+  {
+    editor: "System Security Plan",
+    title: "Enterprise Logging and Auditing System Security Plan",
+    relativeURL: "/system-security-plan/cff8385f-108e-40a5-8f7a-82f3dc0eaba8",
+  },
+];
+describe("Test navigation by URLs route to", () => {
+  it("each of the editors pages", () => {
+    cy.wrap(NAVIGATION).each((element) => {
+      cy.visit(`${Cypress.env("base_url")}${element.relativeURL}`);
+      cy.contains(element.title);
     });
-    it("MongoDB Component Viewer", () => {
-      cy.visit(Cypress.env("base_url") + MONGODB_URL_NAV);
-      cy.contains(MONGODB_NAVIGATION);
-    });
-    it("Profile Version 4 Viewer", () => {
-      cy.visit(Cypress.env("base_url") + PROFILE_V4_URL);
-      cy.contains(PROFILE_NAVIGATION_V4);
-    });
-    it("MongoDB Component Viewer", () => {
-      cy.visit(Cypress.env("base_url") + PROFILE_V5_URL);
-      cy.contains(PROFILE_NAVIGATION_V5);
-    });
-  });
-  it("from Catalog to SSP", () => {
-    cy.navToCatalogEditor(CATALOG_NAVIGATION);
-    cy.visit(Cypress.env("base_url") + SSP_URL_NAV);
-    cy.contains(SSP_NAVIGATION);
-  });
-});
-
-describe("The use URLs to navigate", () => {
-  it("Navigates to Editors by URLs in Random order", () => {
-    cy.navToSspEditor(SSP_NAVIGATION);
-
-    cy.visit(Cypress.env("base_url") + SSP_URL_NAV);
-    cy.contains(SSP_NAVIGATION);
-
-    cy.visit(Cypress.env("base_url") + PROFILE_V5_URL);
-    cy.contains(PROFILE_NAVIGATION_V5);
-
-    cy.visit(Cypress.env("base_url") + PROFILE_V4_URL);
-    cy.contains(PROFILE_NAVIGATION_V4);
-
-    cy.visit(Cypress.env("base_url") + MONGODB_URL_NAV);
-    cy.contains(MONGODB_NAVIGATION);
-
-    cy.visit(Cypress.env("base_url") + CATALOG_URL_NAV);
-    cy.contains(CATALOG_NAVIGATION);
-
-    cy.visit(Cypress.env("base_url") + PROFILE_V4_URL);
-    cy.contains(PROFILE_NAVIGATION_V4);
-
-    cy.visit(Cypress.env("base_url") + SSP_URL_NAV);
-    cy.contains(SSP_NAVIGATION);
-
-    cy.visit(Cypress.env("base_url") + PROFILE_V5_URL);
-    cy.contains(PROFILE_NAVIGATION_V5);
-
-    cy.visit(Cypress.env("base_url") + MONGODB_URL_NAV);
-    cy.contains(MONGODB_NAVIGATION);
-
-    cy.visit(Cypress.env("base_url") + CATALOG_URL_NAV);
-    cy.contains(CATALOG_NAVIGATION);
   });
 });

--- a/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
@@ -41,11 +41,11 @@ const NAVIGATION = [
   },
 ];
 describe("Test that the ", () => {
-  for (let i = 0; i < NAVIGATION.length; i++) {
-    it(`${NAVIGATION[i].editor} Editor loads by URL`, () => {
-      cy.visit(`${Cypress.env("base_url")}${NAVIGATION[i].relativeURL}`);
+  NAVIGATION.forEach((element) => {
+    it(`${element.editor} Editor loads by URL`, () => {
+      cy.visit(`${Cypress.env("base_url")}${element.relativeURL}`);
       cy.waitForLoad();
-      cy.contains(NAVIGATION[i].title);
+      cy.contains(element.title);
     });
-  }
+  });
 });

--- a/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/url_navigation.cy.js
@@ -1,9 +1,15 @@
 const NAVIGATION = [
   {
-    editor: "Catalog",
+    editor: "Catalog Revision 4",
     title:
-      "NIST Special Publication 800-53 Revision 5: Security and Privacy Controls for Federal Information Systems and Organizations",
-    relativeURL: "/catalog/613fca2d-704a-42e7-8e2b-b206fb92b456",
+      "NIST Special Publication 800-53 Revision 4: Security and Privacy Controls for Federal Information Systems and Organizations",
+    relativeURL: "/catalog/b954d3b7-d2c7-453b-8eb2-459e8d3b8462",
+  },
+  {
+    editor: "Catalog Revision 5",
+    title:
+      "Electronic Version of NIST SP 800-53 Rev 5 Controls and SP 800-53A Rev 5 Assessment Procedures",
+    relativeURL: "/catalog/1da16966-2d5b-4e8a-9056-0fe09d35412b",
   },
   {
     editor: "MongoDB",
@@ -34,12 +40,12 @@ const NAVIGATION = [
     relativeURL: "/system-security-plan/cff8385f-108e-40a5-8f7a-82f3dc0eaba8",
   },
 ];
-describe("The Editor", () => {
-  it("Loads the correct pages by url", () => {
-    cy.wrap(NAVIGATION).each((element) => {
-      cy.visit(`${Cypress.env("base_url")}${element.relativeURL}`);
+describe("Test that the ", () => {
+  for (let i = 0; i < NAVIGATION.length; i++) {
+    it(`${NAVIGATION[i].editor} Editor loads by URL`, () => {
+      cy.visit(`${Cypress.env("base_url")}${NAVIGATION[i].relativeURL}`);
       cy.waitForLoad();
-      cy.contains(element.title);
+      cy.contains(NAVIGATION[i].title);
     });
-  });
+  }
 });


### PR DESCRIPTION
One of the many ways to navigate to the Editor views of the
drawer components is to navogate by URLs according to the
uuid (unique tag at the end of the URL).

These sets of tests test that a user can navigate to the various
editors by changing the URL to one that matchs an existing editor.
These tests navigate from one editor page to another editor page.

This also a subtask for issue <a href="https://github.com/EasyDynamics/oscal-react-library/issues/305"> #305</a>