### PR TITLE
Adjust Cypress Testing to `Move Rest Mode Icon`

### DIFF
--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -1,6 +1,6 @@
 const SSP_NAVIGATION = "Enterprise Logging and Auditing System Security Plan";
 const CATALOG_NAVIGATION =
-  "NIST Special Publication 800-53 Revision 5: Security and Privacy Controls for Federal Information Systems and Organizations";
+  "Electronic Version of NIST SP 800-53 Rev 5 Controls and SP 800-53A Rev 5 Assessment Procedures";
 const COMPONENT_NAVIGATION = "Test Component Definition";
 const PROFILE_NAVIGATION_V4 =
   "NIST Special Publication 800-53 Revision 4 MODERATE IMPACT BASELINE";
@@ -49,7 +49,6 @@ describe("The Viewer", () => {
 
   it("loads a catalog", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
-    cy.wait(3000);
     cy.contains("REST Mode").click();
     cy.contains("Catalog");
     cy.contains(CATALOG_NAVIGATION);

--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -8,7 +8,7 @@ const PROFILE_NAVIGATION_V5 =
   "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE";
 const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
 
-describe("The Editor Component", () => {
+describe("The Editor", () => {
   it("loads catalog editor", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
   });

--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -65,7 +65,7 @@ describe("The Viewer", () => {
     cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
     cy.contains("REST Mode").click();
     cy.contains("Profile");
-    cy.contains(PROFILE_NAVIGATION_V4);
+    cy.contains(PROFILE_NAVIGATION_V5);
   });
 
   it("loads a component", () => {

--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -49,6 +49,7 @@ describe("The Viewer", () => {
 
   it("loads a catalog", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
+    cy.wait(3000);
     cy.contains("REST Mode").click();
     cy.contains("Catalog");
     cy.contains(CATALOG_NAVIGATION);

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Edit_Tests.cy.js
@@ -53,7 +53,6 @@ describe('Editing the existing system security plan impl req statement', () => {
 
   it('edits existing system security plan impl req statement', () => {
     const COMPONENT_NAME = 'Enterprise Logging, Monitoring, and Alerting Policy'
-    const PARAM_VALUE_ORIG = 'all staff and contractors within the organization'
     const PARAM_VALUE_NEW = 'some other param value'
     cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.contains('button', COMPONENT_NAME).click()

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -28,7 +28,7 @@ import "@testing-library/cypress/add-commands";
 Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) => {
   let requestsMade = [];
   for (const route of [
-    "catalog",
+    "catalogs",
     "system-security-plans",
     "component-definitions",
     "profiles",
@@ -38,7 +38,6 @@ Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) 
     }).as(route);
   }
   cy.visit(Cypress.env("base_url"));
-  cy.get("button").first().click();
 
   // Wait 1.5s for the events to start firing. In actuality it probably doesn't need to be
   // this log but it also gives time for the handler above to fire as well.

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -39,9 +39,9 @@ Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) 
   }
   cy.visit(Cypress.env("base_url"));
 
-  // Wait 1.5s for the events to start firing. In actuality it probably doesn't need to be
+  // Wait 3s for the events to start firing. In actuality it probably doesn't need to be
   // this log but it also gives time for the handler above to fire as well.
-  cy.wait(1500);
+  cy.wait(3000);
 
   // Wait for any requests that were made to finish. We give all requests 1m. They
   // probably don't need that long, but they can have it.

--- a/end-to-end-tests/cypress/support/e2e.js
+++ b/end-to-end-tests/cypress/support/e2e.js
@@ -28,6 +28,8 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   if (err.message.includes("Cannot read properties of null (reading 'getText')")) {
     return false
   }
+  // TODO: Find a fix where we don't need to avoid this exception
+  // https://github.com/EasyDynamics/oscal-editor-deployment/issues/121
   if (err.message.includes("ResizeObserver loop limit exceeded")) {
     return false
   }

--- a/end-to-end-tests/cypress/support/e2e.js
+++ b/end-to-end-tests/cypress/support/e2e.js
@@ -28,4 +28,7 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   if (err.message.includes("Cannot read properties of null (reading 'getText')")) {
     return false
   }
+  if (err.message.includes("ResizeObserver loop limit exceeded")) {
+    return false
+  }
 })


### PR DESCRIPTION
This addresses testing to fit [oscal-react-library #494](https://github.com/EasyDynamics/oscal-react-library/pull/494). The only major change to cypress testing is a single line to remove the hamburger icon click, as the drawer selector opens automatically now.

This won't pass until [oscal-react-library #494](https://github.com/EasyDynamics/oscal-react-library/pull/494) is merged.