### PR TITLE
Increase wait time

### DIFF
--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -8,7 +8,7 @@ const PROFILE_NAVIGATION_V5 =
   "NIST Special Publication 800-53 Revision 5 MODERATE IMPACT BASELINE";
 const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
 
-describe("Drawer Component", () => {
+describe("The Editor Component", () => {
   it("loads catalog editor", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
   });
@@ -49,6 +49,10 @@ describe("The Viewer", () => {
 
   it("loads a catalog", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
+    // Wait for 3 seconds before changing from REST mode to wait for
+    // Catalog to load in the Editor. The tests sometimes fail if we 
+    // immediately switch to the Viewer.
+    cy.wait(3000);
     cy.contains("REST Mode").click();
     cy.contains("Catalog");
     cy.contains(CATALOG_NAVIGATION);

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -39,9 +39,9 @@ Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) 
   }
   cy.visit(Cypress.env("base_url"));
 
-  // Wait 3s for the events to start firing. In actuality it probably doesn't need to be
+  // Wait 5s for the events to start firing. In actuality it probably doesn't need to be
   // this log but it also gives time for the handler above to fire as well.
-  cy.wait(3000);
+  cy.wait(5000);
 
   // Wait for any requests that were made to finish. We give all requests 1m. They
   // probably don't need that long, but they can have it.


### PR DESCRIPTION
This is a temporary fix for now purely to get the tests to run. Just increasing the `wait` time every time a file we are loading increases in size is not super sustainable. We should look into why these files are taking so long. 

To quote @kylelaker, we need to "look into whether it's a bandwidth issue or if it's a problem with our app's performance itself".