### PR TITLE
Fix intermittent failures

### DIFF
--- a/end-to-end-tests/cypress.config.js
+++ b/end-to-end-tests/cypress.config.js
@@ -9,6 +9,5 @@ module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {},
   },
-  retries: 2,
   video: false,
 })

--- a/end-to-end-tests/cypress.config.js
+++ b/end-to-end-tests/cypress.config.js
@@ -9,6 +9,6 @@ module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {},
   },
-  retries: 1,
+  retries: 2,
   video: false,
 })

--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -10,32 +10,38 @@ const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
 
 describe("The Editor", () => {
   it("loads catalog editor", () => {
-    cy.navToCatalogEditor(CATALOG_NAVIGATION, true);
+    cy.navToCatalogEditor(CATALOG_NAVIGATION);
+    cy.waitForLoad();
     cy.contains(CATALOG_NAVIGATION);
   });
 
   it("loads MongoDB component editor", () => {
-    cy.navToCdefEditor(MONGODB_NAVIGATION, true);
+    cy.navToCdefEditor(MONGODB_NAVIGATION);
+    cy.waitForLoad();
     cy.contains(MONGODB_NAVIGATION);
   });
 
   it("loads test component editor", () => {
-    cy.navToCdefEditor(COMPONENT_NAVIGATION, true);    
+    cy.navToCdefEditor(COMPONENT_NAVIGATION);    
+    cy.waitForLoad();
     cy.contains(COMPONENT_NAVIGATION);
   });
 
   it("loads v4 profile editor", () => {
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V4, true);    
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V4);    
+    cy.waitForLoad();
     cy.contains(PROFILE_NAVIGATION_V4);
   });
 
   it("loads v5 profile editor", () => {
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V5, true);    
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V5);    
+    cy.waitForLoad();
     cy.contains(PROFILE_NAVIGATION_V5);
   });
 
   it("loads system security plan editor", () => {
-    cy.navToSspEditor(SSP_NAVIGATION, true);
+    cy.navToSspEditor(SSP_NAVIGATION);
+    cy.waitForLoad();
     cy.contains(SSP_NAVIGATION);
   });
 
@@ -46,7 +52,8 @@ describe("The Editor", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
     cy.navToCdefEditor(MONGODB_NAVIGATION);
     cy.navToCdefEditor(COMPONENT_NAVIGATION);
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V5, true);
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
+    cy.waitForLoad();
     cy.contains(PROFILE_NAVIGATION_V5);
   });
 });
@@ -61,35 +68,40 @@ describe("The Viewer", () => {
   });
 
   it("loads a catalog", () => {
-    cy.navToCatalogEditor(CATALOG_NAVIGATION, true);
+    cy.navToCatalogEditor(CATALOG_NAVIGATION);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("Catalog");
     cy.contains(CATALOG_NAVIGATION);
   });
 
   it("loads the v4 profile", () => {
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V4, true);
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V4);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("Profile");
     cy.contains(PROFILE_NAVIGATION_V4);
   });
 
   it("loads the v5 profile", () => {
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V5, true);
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("Profile");
     cy.contains(PROFILE_NAVIGATION_V5);
   });
 
   it("loads a component", () => {
-    cy.navToCdefEditor(COMPONENT_NAVIGATION, true);
+    cy.navToCdefEditor(COMPONENT_NAVIGATION);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("Component");
     cy.contains(COMPONENT_NAVIGATION);
   });
 
   it("loads a system security plan", () => {
-    cy.navToSspEditor(SSP_NAVIGATION, true);
+    cy.navToSspEditor(SSP_NAVIGATION);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("System Security Plan");
     cy.contains(SSP_NAVIGATION);

--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -49,10 +49,10 @@ describe("The Viewer", () => {
 
   it("loads a catalog", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
-    // Wait for 3 seconds before changing from REST mode to wait for
+    // Before changing from REST mode to wait for
     // Catalog to load in the Editor. The tests sometimes fail if we 
     // immediately switch to the Viewer.
-    cy.wait(3000);
+    cy.contains(CATALOG_NAVIGATION, { timeout: 10000 });
     cy.contains("REST Mode").click();
     cy.contains("Catalog");
     cy.contains(CATALOG_NAVIGATION);

--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -10,43 +10,44 @@ const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
 
 describe("The Editor", () => {
   it("loads catalog editor", () => {
-    cy.navToCatalogEditor(CATALOG_NAVIGATION);
-    cy.waitForLoad();
+    cy.navToCatalogEditor(CATALOG_NAVIGATION, true);
     cy.contains(CATALOG_NAVIGATION);
   });
 
-  it("loads component editor", () => {
-    cy.navToCdefEditor(MONGODB_NAVIGATION);
-    cy.waitForLoad();
+  it("loads MongoDB component editor", () => {
+    cy.navToCdefEditor(MONGODB_NAVIGATION, true);
     cy.contains(MONGODB_NAVIGATION);
-    cy.navToCdefEditor(COMPONENT_NAVIGATION);    
-    cy.waitForLoad();
+  });
+
+  it("loads test component editor", () => {
+    cy.navToCdefEditor(COMPONENT_NAVIGATION, true);    
     cy.contains(COMPONENT_NAVIGATION);
   });
 
-  it("loads profile component", () => {
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V4);    
-    cy.waitForLoad();
+  it("loads v4 profile editor", () => {
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V4, true);    
     cy.contains(PROFILE_NAVIGATION_V4);
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V5);    
-    cy.waitForLoad();
+  });
+
+  it("loads v5 profile editor", () => {
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V5, true);    
     cy.contains(PROFILE_NAVIGATION_V5);
   });
 
   it("loads system security plan editor", () => {
-    cy.navToSspEditor(SSP_NAVIGATION);
-    cy.waitForLoad();
+    cy.navToSspEditor(SSP_NAVIGATION, true);
     cy.contains(SSP_NAVIGATION);
   });
 
-  it("navigates editors in random order", () => {
+  it("loads after navigating multiple documents", () => {
     cy.navToCdefEditor(MONGODB_NAVIGATION);
     cy.navToSspEditor(SSP_NAVIGATION);
     cy.navToProfileEditor(PROFILE_NAVIGATION_V4);
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
     cy.navToCdefEditor(MONGODB_NAVIGATION);
     cy.navToCdefEditor(COMPONENT_NAVIGATION);
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V5, true);
+    cy.contains(PROFILE_NAVIGATION_V5);
   });
 });
 
@@ -60,40 +61,35 @@ describe("The Viewer", () => {
   });
 
   it("loads a catalog", () => {
-    cy.navToCatalogEditor(CATALOG_NAVIGATION);
-    cy.waitForLoad();
+    cy.navToCatalogEditor(CATALOG_NAVIGATION, true);
     cy.contains("REST Mode").click();
     cy.contains("Catalog");
     cy.contains(CATALOG_NAVIGATION);
   });
 
   it("loads the v4 profile", () => {
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V4);
-    cy.waitForLoad();
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V4, true);
     cy.contains("REST Mode").click();
     cy.contains("Profile");
     cy.contains(PROFILE_NAVIGATION_V4);
   });
 
   it("loads the v5 profile", () => {
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
-    cy.waitForLoad();
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V5, true);
     cy.contains("REST Mode").click();
     cy.contains("Profile");
     cy.contains(PROFILE_NAVIGATION_V5);
   });
 
   it("loads a component", () => {
-    cy.navToCdefEditor(COMPONENT_NAVIGATION);
-    cy.waitForLoad();
+    cy.navToCdefEditor(COMPONENT_NAVIGATION, true);
     cy.contains("REST Mode").click();
     cy.contains("Component");
     cy.contains(COMPONENT_NAVIGATION);
   });
 
   it("loads a system security plan", () => {
-    cy.navToSspEditor(SSP_NAVIGATION);
-    cy.waitForLoad();
+    cy.navToSspEditor(SSP_NAVIGATION, true);
     cy.contains("REST Mode").click();
     cy.contains("System Security Plan");
     cy.contains(SSP_NAVIGATION);

--- a/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/Drawer.cy.js
@@ -11,20 +11,32 @@ const MONGODB_NAVIGATION = "MongoDB Component Definition Example";
 describe("The Editor", () => {
   it("loads catalog editor", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
+    cy.waitForLoad();
+    cy.contains(CATALOG_NAVIGATION);
   });
 
   it("loads component editor", () => {
     cy.navToCdefEditor(MONGODB_NAVIGATION);
-    cy.navToCdefEditor(COMPONENT_NAVIGATION);
+    cy.waitForLoad();
+    cy.contains(MONGODB_NAVIGATION);
+    cy.navToCdefEditor(COMPONENT_NAVIGATION);    
+    cy.waitForLoad();
+    cy.contains(COMPONENT_NAVIGATION);
   });
 
   it("loads profile component", () => {
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V4);
-    cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V4);    
+    cy.waitForLoad();
+    cy.contains(PROFILE_NAVIGATION_V4);
+    cy.navToProfileEditor(PROFILE_NAVIGATION_V5);    
+    cy.waitForLoad();
+    cy.contains(PROFILE_NAVIGATION_V5);
   });
 
   it("loads system security plan editor", () => {
     cy.navToSspEditor(SSP_NAVIGATION);
+    cy.waitForLoad();
+    cy.contains(SSP_NAVIGATION);
   });
 
   it("navigates editors in random order", () => {
@@ -49,10 +61,7 @@ describe("The Viewer", () => {
 
   it("loads a catalog", () => {
     cy.navToCatalogEditor(CATALOG_NAVIGATION);
-    // Before changing from REST mode to wait for
-    // Catalog to load in the Editor. The tests sometimes fail if we 
-    // immediately switch to the Viewer.
-    cy.contains(CATALOG_NAVIGATION, { timeout: 10000 });
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("Catalog");
     cy.contains(CATALOG_NAVIGATION);
@@ -60,6 +69,7 @@ describe("The Viewer", () => {
 
   it("loads the v4 profile", () => {
     cy.navToProfileEditor(PROFILE_NAVIGATION_V4);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("Profile");
     cy.contains(PROFILE_NAVIGATION_V4);
@@ -67,6 +77,7 @@ describe("The Viewer", () => {
 
   it("loads the v5 profile", () => {
     cy.navToProfileEditor(PROFILE_NAVIGATION_V5);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("Profile");
     cy.contains(PROFILE_NAVIGATION_V5);
@@ -74,6 +85,7 @@ describe("The Viewer", () => {
 
   it("loads a component", () => {
     cy.navToCdefEditor(COMPONENT_NAVIGATION);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("Component");
     cy.contains(COMPONENT_NAVIGATION);
@@ -81,6 +93,7 @@ describe("The Viewer", () => {
 
   it("loads a system security plan", () => {
     cy.navToSspEditor(SSP_NAVIGATION);
+    cy.waitForLoad();
     cy.contains("REST Mode").click();
     cy.contains("System Security Plan");
     cy.contains(SSP_NAVIGATION);

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -46,7 +46,7 @@ Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) 
   }
   
   cy.get('ul')
-    .find('li', { timeout: 10000 })
+    .find('li', { timeout: 15000 })
     .should('have.attr', 'aria-expanded', 'false') 
     .contains(viewerLinkText)
     .click();

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -39,21 +39,19 @@ Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) 
   }
   cy.visit(Cypress.env("base_url"));
 
-  // Wait 5s for the events to start firing. In actuality it probably doesn't need to be
-  // this log but it also gives time for the handler above to fire as well.
-  cy.wait(5000);
-
   // Wait for any requests that were made to finish. We give all requests 1m. They
   // probably don't need that long, but they can have it.
   if (requestsMade.length) {
     cy.wait(requestsMade, { timeout: 60000 });
   }
-
-  cy.get("p")
+  
+  cy.get('ul')
+    .find('li', { timeout: 10000 })
+    .should('have.attr', 'aria-expanded', 'false') 
     .contains(viewerLinkText)
-    .should("be.visible")
-    .click({ timeout: 100000 });
-  cy.contains(navigationProfile, { timeout: 10000 }).click();
+    .click();
+
+  cy.contains(navigationProfile).click();
 });
 
 Cypress.Commands.add("navToSspEditor", (toNavigate) => {

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -25,7 +25,11 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 import "@testing-library/cypress/add-commands";
 
-Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) => {
+Cypress.Commands.add("waitForLoad", () => {
+  cy.get('circle', { timeout: 10000 } ).should('not.exist');
+});
+
+Cypress.Commands.add("navToEditorByDrawer", (oscalType, pageTitle, shouldWait) => {
   let requestsMade = [];
   for (const route of [
     "catalogs",
@@ -48,26 +52,39 @@ Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) 
   cy.get('ul[aria-label="file system navigator"]')
     .find('li', { timeout: 15000 })
     .should('have.attr', 'aria-expanded', 'false') 
-    .contains(viewerLinkText)
+    .contains(oscalType)
     .click();
 
-  cy.contains(navigationProfile).click();
+  cy.contains(pageTitle).click();
+
+  if (shouldWait) {
+    cy.waitForLoad();
+  }
 });
 
-Cypress.Commands.add("navToSspEditor", (toNavigate) => {
-  cy.navToEditorByDrawer("System Security Plan", toNavigate);
-});
+const oscalObjectTypes = [
+  {
+    commandName: "navToSspEditor",
+    oscalType: "System Security Plan",
+  },
+  {
+    commandName: "navToCdefEditor",
+    oscalType: "Component",
+  },
+  {
+    commandName: "navToProfileEditor",
+    oscalType: "Profile",
+  },
+  {
+    commandName: "navToCatalogEditor",
+    oscalType: "Catalog",
+  },
+]
 
-Cypress.Commands.add("navToCdefEditor", (toNavigate) => {
-  cy.navToEditorByDrawer("Component", toNavigate);
-});
-
-Cypress.Commands.add("navToProfileEditor", (toNavigate) => {
-  cy.navToEditorByDrawer("Profile", toNavigate);
-});
-
-Cypress.Commands.add("navToCatalogEditor", (toNavigate) => {
-  cy.navToEditorByDrawer("Catalog", toNavigate);
+oscalObjectTypes.map((oscalObjectType) => {
+  Cypress.Commands.add(oscalObjectType.commandName, (pageTitle, shouldWait=false) => {
+    cy.navToEditorByDrawer(oscalObjectType.oscalType, pageTitle, shouldWait);
+  })
 });
 
 Cypress.Commands.add("getInputByLabel", (label) => {
@@ -100,6 +117,3 @@ Cypress.Commands.add("setTestSspJson", (sspJson) => {
   );
 });
 
-Cypress.Commands.add("waitForLoad", () => {
-  cy.get('circle', { timeout: 10000 } ).should('not.exist');
-});

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -29,7 +29,7 @@ Cypress.Commands.add("waitForLoad", () => {
   cy.get('circle', { timeout: 10000 } ).should('not.exist');
 });
 
-Cypress.Commands.add("navToEditorByDrawer", (oscalType, pageTitle, shouldWait) => {
+Cypress.Commands.add("navToEditorByDrawer", (oscalType, pageTitle) => {
   let requestsMade = [];
   for (const route of [
     "catalogs",
@@ -56,10 +56,6 @@ Cypress.Commands.add("navToEditorByDrawer", (oscalType, pageTitle, shouldWait) =
     .click();
 
   cy.contains(pageTitle).click();
-
-  if (shouldWait) {
-    cy.waitForLoad();
-  }
 });
 
 const oscalObjectTypes = [
@@ -82,8 +78,8 @@ const oscalObjectTypes = [
 ]
 
 oscalObjectTypes.forEach((oscalObjectType) => {
-  Cypress.Commands.add(oscalObjectType.commandName, (pageTitle, shouldWait=false) => {
-    cy.navToEditorByDrawer(oscalObjectType.oscalType, pageTitle, shouldWait);
+  Cypress.Commands.add(oscalObjectType.commandName, (pageTitle) => {
+    cy.navToEditorByDrawer(oscalObjectType.oscalType, pageTitle);
   })
 });
 

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -81,7 +81,7 @@ const oscalObjectTypes = [
   },
 ]
 
-oscalObjectTypes.map((oscalObjectType) => {
+oscalObjectTypes.forEach((oscalObjectType) => {
   Cypress.Commands.add(oscalObjectType.commandName, (pageTitle, shouldWait=false) => {
     cy.navToEditorByDrawer(oscalObjectType.oscalType, pageTitle, shouldWait);
   })

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -99,3 +99,7 @@ Cypress.Commands.add("setTestSspJson", (sspJson) => {
     sspJson
   );
 });
+
+Cypress.Commands.add("waitForLoad", () => {
+  cy.get('circle', { timeout: 10000} ).should('not.exist');
+});

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -45,7 +45,7 @@ Cypress.Commands.add("navToEditorByDrawer", (viewerLinkText, navigationProfile) 
     cy.wait(requestsMade, { timeout: 60000 });
   }
   
-  cy.get('ul')
+  cy.get('ul[aria-label="file system navigator"]')
     .find('li', { timeout: 15000 })
     .should('have.attr', 'aria-expanded', 'false') 
     .contains(viewerLinkText)
@@ -101,5 +101,5 @@ Cypress.Commands.add("setTestSspJson", (sspJson) => {
 });
 
 Cypress.Commands.add("waitForLoad", () => {
-  cy.get('circle', { timeout: 10000} ).should('not.exist');
+  cy.get('circle', { timeout: 10000 } ).should('not.exist');
 });


### PR DESCRIPTION
## Catalog in Drawer failures
Rather than always waiting to load and looking for a paragraph tag, this
will better replicate how a user would use the drawer.

The user looks for a list of OSCAL Object types, waits to see that those
items are expandable, then will select the item they want.

## Switching to non REST mode failures
~I am still not 100% convinced this has been fixed. We will need to test this a bit more before we merge this in.~ 
Previously, we were not actually waiting for the page to load to do anything. `waitForLoad` waits for the loading icon to disappear before doing anything, or for the timeout to end, whichever comes first. With this, I also realized we were not actually testing anything with the `Editor` tests, so they now wait to load and check for the title to appear. 

Should close #123
