### PR TITLE
Switch to using distroless image

### DIFF
--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -66,19 +66,13 @@ RUN if [ -n "$REST_PATH" ]; \
     mv oscal-rest-service-app/target/oscal-rest-service-app*.jar "/app/oscal-rest-service-app.jar"; \
     fi
 
-FROM openjdk:${JAVA_VERSION}-slim-bullseye
+FROM gcr.io/distroless/java11-debian11
 
 #copy production build of OSCAL Viewer
 COPY --from=build-viewer /app/build /app/oscal-viewer-app
 COPY --from=build-service /app/oscal-rest-service-app.jar /app/oscal-rest-service-app.jar
 
-#add a new group and add a new user to the group
-#give permissions in the /app/ directory to the new user
-RUN addgroup --system oscaledit && \
-    adduser --system oscaledit --ingroup oscaledit && \
-    chown -R oscaledit /app/
-
-USER oscaledit
+USER nonroot:nonroot
 
 #set environment variables for the oscal content directory
 #and location of the production build to be served by Spring Boot
@@ -87,6 +81,6 @@ ENV PERSISTENCE_FILE_PARENT_PATH="oscal-content" \
 
 EXPOSE 8080
 
-WORKDIR /app/
+WORKDIR /app
 
-ENTRYPOINT ["java", "-jar", "oscal-rest-service-app.jar"]
+CMD ["oscal-rest-service-app.jar"]


### PR DESCRIPTION
In order to switch to using a distroless image, the base image obviously
has to change, but a couple other items in the Dockerfile have to be
modified as well. The USER is now set to a pre-existing non-root user
and group, both named "nonroot". The ENTRYPOINT command has also been
replaced with CMD to avoid the container attempting to use /bin/sh that
doesn't exist within the image.
