### PR TITLE
feat(docker)!: Switch to using distroless image

### DIFF
--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -67,7 +67,7 @@ RUN if [ -n "$REST_PATH" ]; \
     mv oscal-rest-service-app/target/oscal-rest-service-app*.jar "/app/oscal-rest-service-app.jar"; \
     fi
 
-FROM gcr.io/distroless/java${JAVA_VERSION}-debian11
+FROM gcr.io/distroless/java${JAVA_VERSION}-debian11:nonroot
 
 #copy production build of OSCAL Viewer
 COPY --from=build-viewer /app/build /app/oscal-viewer-app

--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -67,19 +67,13 @@ RUN if [ -n "$REST_PATH" ]; \
     mv oscal-rest-service-app/target/oscal-rest-service-app*.jar "/app/oscal-rest-service-app.jar"; \
     fi
 
-FROM openjdk:${JAVA_VERSION}-slim-bullseye
+FROM gcr.io/distroless/java11-debian11
 
 #copy production build of OSCAL Viewer
 COPY --from=build-viewer /app/build /app/oscal-viewer-app
 COPY --from=build-service /app/oscal-rest-service-app.jar /app/oscal-rest-service-app.jar
 
-#add a new group and add a new user to the group
-#give permissions in the /app/ directory to the new user
-RUN addgroup --system oscaledit && \
-    adduser --system oscaledit --ingroup oscaledit && \
-    chown -R oscaledit /app/
-
-USER oscaledit
+USER nonroot:nonroot
 
 #set environment variables for the oscal content directory
 #and location of the production build to be served by Spring Boot
@@ -88,6 +82,6 @@ ENV PERSISTENCE_FILE_PARENT_PATH="oscal-content" \
 
 EXPOSE 8080
 
-WORKDIR /app/
+WORKDIR /app
 
-ENTRYPOINT ["java", "-jar", "oscal-rest-service-app.jar"]
+CMD ["oscal-rest-service-app.jar"]

--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -5,8 +5,8 @@
 #  2. Build the oscal-rest-service. This phase happens in an OpenJDK image.
 #     Like with the viewer, if a prebuilt JAR file is provided, that is used.
 #     Otherwise, the service is built from source.
-#  3. The final "runtime" container is built. This is based off an OpenJDK JRE
-#     container with minimal additional software installed.
+#  3. The final "runtime" container is built. This is based off the Distroless
+#     Java image with minimal additional software installed.
 #  Steps 1 & 2 place their artifacts in /app/ and Step 3 copies the final artifact
 #  into its /app/ directory with the appropriate filename.
 
@@ -69,14 +69,14 @@ RUN if [ -n "$REST_PATH" ]; \
 
 FROM gcr.io/distroless/java${JAVA_VERSION}-debian11:nonroot
 
-#copy production build of OSCAL Viewer
 COPY --from=build-viewer /app/build /app/oscal-viewer-app
 COPY --from=build-service /app/oscal-rest-service-app.jar /app/oscal-rest-service-app.jar
 
 USER nonroot:nonroot
 
-#set environment variables for the oscal content directory
-#and location of the production build to be served by Spring Boot
+# Apply default configuration values via environment variable for the location of the OSCAL
+# Content directory as well as the location of the OSCAL Viewer/Editor application to be
+# served by the Spring app.
 ENV PERSISTENCE_FILE_PARENT_PATH="oscal-content" \
     SPRING_WEB_RESOURCES_STATIC_LOCATIONS="classpath:/static,file:/app/oscal-viewer-app/"
 

--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -67,7 +67,7 @@ RUN if [ -n "$REST_PATH" ]; \
     mv oscal-rest-service-app/target/oscal-rest-service-app*.jar "/app/oscal-rest-service-app.jar"; \
     fi
 
-FROM gcr.io/distroless/java11-debian11
+FROM gcr.io/distroless/java${JAVA_VERSION}-debian11
 
 #copy production build of OSCAL Viewer
 COPY --from=build-viewer /app/build /app/oscal-viewer-app


### PR DESCRIPTION
In order to switch to using a distroless image, the base image obviously
has to change, but a couple other items in the Dockerfile have to be
modified as well. The USER is now set to a pre-existing non-root user
and group, both named "nonroot". The ENTRYPOINT command has also been
replaced with CMD to avoid the container attempting to use /bin/sh that
doesn't exist within the image.

BREAKING CHANGE: the base image of the resulting container has changed 
