### PR TITLE
Configure automatically generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+---
+changelog:
+  exclude:
+    labels:
+      - chore
+      - dependencies
+      - spike
+  categories:
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug


### PR DESCRIPTION
This adds support for automatically generating release notes.

The release notes workflow supports relevant updates to a user such as `Bug Fixes` and `New Features`. For now, only the bug and enhancement labels show bug fixes and newly added features. Labels such as chore, dependencies, and spike will be excluded because it is not as relevant information to a consumer. Using GitHub's [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration) feature easily allows us to change this as we add/remove labels in the future.

Relates to https://github.com/EasyDynamics/oscal-react-library/issues/457.