### PR TITLE
Remove commas from workflow name

### DIFF
--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -1,4 +1,4 @@
-name: Build Test Deploy
+name: Build/Test/Deploy
 on:
   push:
     branches:

--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -1,4 +1,4 @@
-name: Build, Test, Deploy
+name: Build Test Deploy
 on:
   push:
     branches:


### PR DESCRIPTION
With the addition of having [teams notifications for workflows](https://github.blog/changelog/2022-12-06-github-actions-workflow-notifications-in-slack-and-microsoft-teams/), it made sense to get notified on deployments to `main`. However, the name of the workflow containing commas causes a lot of issues. This seems like an easier way to deal with that problem.
