### PR TITLE
Use latest version of npm in docker build

### DIFF
--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -36,6 +36,7 @@ RUN if [ -n "$VIEWER_PATH" ] ; \
     rm -rf /app/build && \
     git clone --branch "$OSCAL_REACT_GIT_BRANCH" --depth 1 -- "$OSCAL_REACT_GIT_REPO" "$OSCAL_REACT_DIR" && \
     cd "$OSCAL_REACT_DIR" && \
+    npm install -g npm@latest && \
     npm ci && \
     cd example && \
     npm ci && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "oscal-editor-deployment",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
To stop the docker build from failing, this adds a step to update to the latest version of `npm`.