### PR TITLE
fix(workflows): auto-update workflow fails on cache setup

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -32,6 +32,7 @@ jobs:
           # to us.
           node-version: "lts/*"
           cache: npm
+          cache-dependency-path: end-to-end-tests/package-lock.json
 
       - name: Install latest npm and and npm-check-updates
         run: npm install -g npm@latest npm-check-updates@latest


### PR DESCRIPTION
In a recent PR we deleted the `package-lock.json` (which was good
because it was not correct to have it there); however, that was what was
allowing `cache: npm` in the configuration for `setup-node`. That
shouldn't have been the way things were working because the cache key
would be sorta borked and changes wouldn't really be detected correctly.
We now use the `cache-dependency-path` configuration value that allows
specifying the path the lock file.

For a sample failing build, see:
https://github.com/EasyDynamics/oscal-editor-deployment/actions/runs/4005864680