### PR TITLE
fix(cypress): Cypress tests timing out and failing

### DIFF
--- a/end-to-end-tests/cypress.config.js
+++ b/end-to-end-tests/cypress.config.js
@@ -11,5 +11,5 @@ module.exports = defineConfig({
   },
   retries: 1,
   video: false,
-  defaultCommandTimeout: 30000,
+  defaultCommandTimeout: 60000,
 })


### PR DESCRIPTION
This increases timeout before tests fail. The test have been failing mostly due to how long it takes to load various OSCAL documents. This will hopefully make that happen a lot less. 