### PR TITLE
chore(workflows): dont write container logs to stdout

### DIFF
--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -63,10 +63,10 @@ jobs:
           spec: cypress/e2e/**/*.cy.js
           working-directory: end-to-end-tests
 
-      - name: Output Docker Container Logs
+      - name: Emit Docker Container Logs to file
         if: always()
         run: |
-          docker logs ${CONTAINER_NAME} | tee container-logs.txt
+          docker logs ${CONTAINER_NAME} &> container-logs.txt
 
       - name: Upload Docker Container Logs
         if: always()


### PR DESCRIPTION
When running the CI workflow, the logs are written to stdout and also to
a file (using `tee(1)`). While this is sometimes helpful (because the
logs are visible in the Actions tab), it's usually more detrimental
(because there are too many logs). In fact, we currently have so many
logs that GitHub Actions wastes 3.5min just writing out logs, and that
slows down the process for getting feedback from CI.
