### PR TITLE
chore(workflows): avoid building the container twice

### DIFF
--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -49,7 +49,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=edge,branch=main
-            type=raw,value=latest,enable=${{ github.repository === 'EasyDynamics/oscal-editor-deployment' && github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.repository == 'EasyDynamics/oscal-editor-deployment' && github.ref == 'refs/heads/main' }}
           labels: |
             org.opencontainers.image.title=oscal-editor-all-in-one
             org.opencontainers.image.description=Simple Docker deployment of the back-end services and web-based user interface for the OSCAL Editor

--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -39,7 +39,6 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Extract metadata for Docker
-        if: ${{ github.event_name != 'pull_request' }}
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -50,7 +49,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=edge,branch=main
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.repository === 'EasyDynamics/oscal-editor-deployment' && github.ref == 'refs/heads/main' }}
           labels: |
             org.opencontainers.image.title=oscal-editor-all-in-one
             org.opencontainers.image.description=Simple Docker deployment of the back-end services and web-based user interface for the OSCAL Editor

--- a/.github/workflows/container-test-deploy.yml
+++ b/.github/workflows/container-test-deploy.yml
@@ -38,6 +38,24 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Extract metadata for Docker
+        if: ${{ github.event_name != 'pull_request' }}
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            easydynamics/${{ env.IMAGE_NAME }}
+            ghcr.io/easydynamics/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=edge,branch=main
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+          labels: |
+            org.opencontainers.image.title=oscal-editor-all-in-one
+            org.opencontainers.image.description=Simple Docker deployment of the back-end services and web-based user interface for the OSCAL Editor
+            org.opencontainers.image.vendor=Easy Dynamics
+
       # Build the Docker image, and load it locally so it can be run for testing
       - name: Build Docker Image
         uses: docker/build-push-action@v4
@@ -45,7 +63,8 @@ jobs:
           context: ./all-in-one
           load: true
           provenance: false
-          tags: ${{ env.IMAGE_NAME }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
 
       # Run container in the background, exposing the port that
       # Cypress uses to run the tests.
@@ -55,7 +74,7 @@ jobs:
           ls -al $(pwd)/all-in-one/oscal-content;
           docker run --rm -p 8080:8080 \
           -v $(pwd)/all-in-one/oscal-content:/app/oscal-content \
-          --name ${CONTAINER_NAME} ${IMAGE_NAME} &
+          --name ${CONTAINER_NAME} easydynamics/${IMAGE_NAME} &
 
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v5
@@ -104,24 +123,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata for Docker
-        if: ${{ github.event_name != 'pull_request' }}
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            easydynamics/${{ env.IMAGE_NAME }}
-            ghcr.io/easydynamics/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=edge,branch=main
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-          labels: |
-            org.opencontainers.image.title=oscal-editor-all-in-one
-            org.opencontainers.image.description=Simple Docker deployment of the back-end services and web-based user interface for the OSCAL Editor
-            org.opencontainers.image.vendor=Easy Dynamics
 
       - name: Push to Container Registries
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
It seems like the workflow is not using the cache from the first build
and is instead building and pushing again on the `push` step. Hopefully
reusing the tabs and labels between the jobs helps with this? Let's find
out!

Note that a full test requires a `push` event on the `main` branch in
order to work because of how the workflow works. So we need to keep an
eye on the merge to `main` to ensure this works properly (but we also
should not see regressions in the PR).
