### PR TITLE
chore(workflow): refactor container image workflow

### DIFF
--- a/.github/workflows/deploy-container-main.yml
+++ b/.github/workflows/deploy-container-main.yml
@@ -1,15 +1,14 @@
-name: Build/Test/Deploy
+name: Build/Test/Deploy Container
 on:
   push:
     branches:
       - main
     tags:
       - 'v*'
-  pull_request:
   workflow_dispatch:
   schedule:
-    # Run daily at 12:15 UTC (08:15 EDT/07:15 EST)
-    - cron: "15 12 * * *"
+    # Run daily at 10:15 UTC (06:15 EDT/05:15 EST)
+    - cron: "15 10 * * *"
 
 env:
   IMAGE_NAME: oscal-editor-all-in-one
@@ -38,14 +37,33 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            easydynamics/${{ env.IMAGE_NAME }}
+            ghcr.io/easydynamics/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=edge,branch=main
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+          labels: |
+            org.opencontainers.image.title=oscal-editor-all-in-one
+            org.opencontainers.image.description=Simple Docker deployment of the back-end services and web-based user interface for the OSCAL Editor
+            org.opencontainers.image.vendor=Easy Dynamics
+
       # Build the Docker image, and load it locally so it can be run for testing
       - name: Build Docker Image
         uses: docker/build-push-action@v4
         with:
           context: ./all-in-one
+          push: false
           load: true
           provenance: false
-          tags: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       # Run container in the background, exposing the port that
       # Cypress uses to run the tests.
@@ -91,51 +109,29 @@ jobs:
           docker stop ${CONTAINER_NAME}
 
       - name: Login to Docker Hub
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker
-        if: ${{ github.event_name != 'pull_request' }}
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            easydynamics/${{ env.IMAGE_NAME }}
-            ghcr.io/easydynamics/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=edge,branch=main
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-          labels: |
-            org.opencontainers.image.title=oscal-editor-all-in-one
-            org.opencontainers.image.description=Simple Docker deployment of the back-end services and web-based user interface for the OSCAL Editor
-            org.opencontainers.image.vendor=Easy Dynamics
-
       - name: Push to Container Registries
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/build-push-action@v4
         with:
           context: ./all-in-one
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
 
       # This uses the peter-evans workflow: https://github.com/peter-evans/dockerhub-description
       - name: Update Docker Hub Short-Description & Overview
-        if: ${{ github.event_name != 'pull_request' }}
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/test-container-pr.yml
+++ b/.github/workflows/test-container-pr.yml
@@ -7,8 +7,8 @@ env:
   CONTAINER_NAME: test_container
 
 jobs:
-  build_test_deploy:
-    name: Build, Test, and Deploy All-in-One Docker Image
+  build_test:
+    name: Build and Test All-in-One Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/test-container-pr.yml
+++ b/.github/workflows/test-container-pr.yml
@@ -1,0 +1,82 @@
+name: Build & Test Container
+on:
+  pull_request: ~
+
+env:
+  IMAGE_NAME: oscal-editor-all-in-one
+  CONTAINER_NAME: test_container
+
+jobs:
+  build_test_deploy:
+    name: Build, Test, and Deploy All-in-One Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install Tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq xmlstarlet curl wget
+
+      # Get Default OSCAL Content for testing
+      - name: Pull OSCAL Content
+        uses: actions/checkout@v3
+        with:
+          repository: EasyDynamics/oscal-demo-content
+          path: all-in-one/oscal-content
+
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      # Build the Docker image, and load it locally so it can be run for testing
+      - name: Build Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./all-in-one
+          load: true
+          provenance: false
+          tags: ${{ env.IMAGE_NAME }}
+
+      # Run container in the background, exposing the port that
+      # Cypress uses to run the tests.
+      - name: Run Docker Container for Tests
+        run: |
+          chmod -R go+w $(pwd)/all-in-one/oscal-content;
+          ls -al $(pwd)/all-in-one/oscal-content;
+          docker run --rm -p 8080:8080 \
+          -v $(pwd)/all-in-one/oscal-content:/app/oscal-content \
+          --name ${CONTAINER_NAME} ${IMAGE_NAME} &
+
+      - name: Run Cypress Tests
+        uses: cypress-io/github-action@v5
+        with:
+          spec: cypress/e2e/**/*.cy.js
+          working-directory: end-to-end-tests
+
+      - name: Emit Docker Container Logs to file
+        if: always()
+        run: |
+          docker logs ${CONTAINER_NAME} &> container-logs.txt
+
+      - name: Upload Docker Container Logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker-logs
+          path: container-logs.txt
+
+      # Upload the screenshots and videos of a Cypress test failure
+      # to the artifacts of this workflow on GitHub
+      - name: Upload Cypress Artifacts
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress-results
+          path: |
+            ./end-to-end-tests/cypress/screenshots
+            ./end-to-end-tests/cypress/videos
+
+      - name: Stop Running Container
+        run:
+          docker stop ${CONTAINER_NAME}


### PR DESCRIPTION
This refactors the whole workflow a bit. It splits the deployment steps
into a separate workflow with fewer triggers. This removes the
`if: ${{github.event_name == 'pull_request' }}` checks that were all
over the place and made it harder to reason about when things ran. It
also ensures that no matter what, these steps can only be run from a
more trusted branch (`main` and tags) while the more flexible testing
workflow no longer has the deploy step anywhere in it and means we don't
have to be quite as strict about the checks on the tags.

This should also incorporate the goals from #224 and avoid building the
container image twice when we run on the `main` branch. This likely
won't make things much faster for PRs but hopefully it's less confusing.
