### PR TITLE
chore(workflow): wait after starting container before running tests

### DIFF
--- a/.github/workflows/deploy-container-main.yml
+++ b/.github/workflows/deploy-container-main.yml
@@ -76,6 +76,11 @@ jobs:
           -v $(pwd)/all-in-one/oscal-content:/app/oscal-content \
           --name ${CONTAINER_NAME} ${TEST_TAG} &
 
+      # Give the container time to start before starting to hammer it with tests
+      - name: Wait 10 sec
+        run: |
+          sleep 10
+
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v5
         with:

--- a/.github/workflows/test-container-pr.yml
+++ b/.github/workflows/test-container-pr.yml
@@ -48,6 +48,11 @@ jobs:
           -v $(pwd)/all-in-one/oscal-content:/app/oscal-content \
           --name ${CONTAINER_NAME} ${IMAGE_NAME} &
 
+      # Give the container time to start before starting to hammer it with tests
+      - name: Wait 10 sec
+        run: |
+          sleep 10
+
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v5
         with:


### PR DESCRIPTION
This may not help but I am curious if it cuts down on the very slow
first test that we often see...
