### PR TITLE
feat(cypress): Test locations & roles display

### DIFF
--- a/.github/workflows/deploy-container-main.yml
+++ b/.github/workflows/deploy-container-main.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: EasyDynamics/oscal-demo-content
+          ref: "test-content"
           path: all-in-one/oscal-content
 
       - name: Set Up Docker Buildx

--- a/.github/workflows/test-container-pr.yml
+++ b/.github/workflows/test-container-pr.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: EasyDynamics/oscal-demo-content
+          ref: "test-content"
           path: all-in-one/oscal-content
 
       - name: Set Up Docker Buildx

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Load_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Load_Tests.cy.js
@@ -25,6 +25,7 @@ describe('Loading system security plans', () => {
   it('displays Enterprise Asset Owners Party', () => {
     cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.waitForLoad();
+    cy.contains("Parties").click();
     cy.get(`[aria-label="Enterprise Asset Owners details button"]`).click();
     cy.contains("No address information provided");
     cy.contains("No telephone information provided");
@@ -34,6 +35,7 @@ describe('Loading system security plans', () => {
   it('displays Enterprise Asset Administrators Party', () => {
     cy.navToSspEditor(SSP_TITLE_ORIG);
     cy.waitForLoad();
+    cy.contains("Parties").click();
     cy.get(`[aria-label="Enterprise Asset Administrators details button"]`).click();
     cy.contains("0000 St");
     cy.contains("+18005555555");
@@ -47,6 +49,7 @@ describe('Loading Component Definitions', () => {
     cy.navToCdefEditor(COMP_DEF_TITLE_ORIG)
     cy.waitForLoad();
     cy.contains(COMP_DEF_TITLE_ORIG).should('be.visible')
+    cy.contains("Parties").click();
     cy.contains('Test Vendor').should('be.visible')
     cy.scrollTo('bottom')
   })
@@ -58,9 +61,47 @@ describe('Loading Component Definitions', () => {
     cy.contains('OSCAL Component URL').first().should('exist').next().click().clear().type(Cypress.env('base_url') + "/oscal/v1/component-definitions/8223d65f-57a9-4689-8f06-2a975ae2ad72")
     cy.contains('Reload').click()
     cy.contains(COMP_DEF_TITLE_ORIG).should('be.visible')
+    cy.contains("Parties").click();
     cy.contains('Test Vendor').should('be.visible')
     cy.scrollTo('bottom')
-  })
+  });
+  
+  it('loads metadata roles', () => {
+    cy.navToCdefEditor(COMP_DEF_TITLE_ORIG);
+    cy.waitForLoad();
+    cy.contains("Roles").click();
+    cy.contains("Document creator");
+    cy.contains("Contact");
+  });
+
+  it('loads metadata role details', () => {
+    cy.navToCdefEditor(COMP_DEF_TITLE_ORIG);
+    cy.waitForLoad();
+    cy.contains("Roles").click();
+    cy.get(`[aria-label="Document creator details button"]`).click();
+    cy.contains("Creates documents describing the system");
+  });
+
+  it('loads metadata locations', () => {
+    cy.navToCdefEditor(COMP_DEF_TITLE_ORIG);
+    cy.waitForLoad();
+    cy.contains("Locations").click();
+    cy.contains("NIST");
+    cy.contains("Not Specified");
+  });
+
+  it('loads metadata location details', () => {
+    cy.navToCdefEditor(COMP_DEF_TITLE_ORIG);
+    cy.waitForLoad();
+    cy.contains("Locations").click();
+    cy.get(`[aria-label="NIST details button"]`).click();
+    cy.contains("100 Bureau Drive");
+    cy.contains("Mail Stop 8970");
+    cy.contains("Gaithersburg, MD 20899-8970");
+    cy.contains("301-975-8616");
+    cy.contains("itl_inquiries@nist.gov");
+    cy.contains("https://www.nist.gov/");
+  });
 })
 
 describe('Errors caused by loading a bad component definition', () => {

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -112,3 +112,10 @@ Cypress.Commands.add("setTestSspJson", (sspJson) => {
   );
 });
 
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
+Cypress.on('uncaught:exception', (err) => {
+    /* returning false here prevents Cypress from failing the test */
+    if (resizeObserverLoopErrRe.test(err.message)) {
+        return false
+    }
+})

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -111,11 +111,3 @@ Cypress.Commands.add("setTestSspJson", (sspJson) => {
     sspJson
   );
 });
-
-const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
-Cypress.on('uncaught:exception', (err) => {
-    /* returning false here prevents Cypress from failing the test */
-    if (resizeObserverLoopErrRe.test(err.message)) {
-        return false
-    }
-})

--- a/end-to-end-tests/cypress/support/e2e.js
+++ b/end-to-end-tests/cypress/support/e2e.js
@@ -19,18 +19,20 @@ import './commands'
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-Cypress.on('uncaught:exception', (err, runnable) => {
+Cypress.on('uncaught:exception', (err) => {
   // monaco-editor sometimes throws errors when reloading
   // and we don't want to fail the test so we return false
   if (err.message.includes("Failed to execute 'importScripts' on 'WorkerGlobalScope'")) {
     return false
   }
+
   if (err.message.includes("Cannot read properties of null (reading 'getText')")) {
     return false
   }
+  
   // TODO: Find a fix where we don't need to avoid this exception
   // https://github.com/EasyDynamics/oscal-editor-deployment/issues/121
-  if (err.message.includes("ResizeObserver loop limit exceeded")) {
+  if (err.message.includes("ResizeObserver loop")) {
     return false
   }
 })


### PR DESCRIPTION
To avoid regression after https://github.com/EasyDynamics/oscal-react-library/pull/728
is merged in, this tests that locations and roles display properly.

It will require changes from https://github.com/EasyDynamics/oscal-demo-content/pull/35
for the tests to pass.
