### PR TITLE
chore(all-in-one): support new React library layout

### DIFF
--- a/all-in-one/Dockerfile
+++ b/all-in-one/Dockerfile
@@ -38,10 +38,8 @@ RUN if [ -n "$VIEWER_PATH" ] ; \
     cd "$OSCAL_REACT_DIR" && \
     npm install -g npm@latest && \
     npm ci && \
-    cd example && \
-    npm ci && \
     REACT_APP_REST_BASE_URL="$OSCAL_REST_BASE_URL" npm run build && \
-    mv build /app/ ; \
+    mv packages/oscal-viewer/build /app/ ; \
     fi
 
 FROM maven:3-openjdk-${JAVA_VERSION} as build-service


### PR DESCRIPTION
This unblocks the build after easydynamics/oscal-react-library#722 was merged.