### PR TITLE
fix: tests failed to open catalog list

### DIFF
--- a/.github/workflows/test-container-pr.yml
+++ b/.github/workflows/test-container-pr.yml
@@ -68,8 +68,6 @@ jobs:
           load: true
           provenance: false
           tags: ${{ env.IMAGE_NAME }}
-          build-args: |
-            "OSCAL_REACT_GIT_BRANCH=tuckerzp/test-before-react-18"
 
       # Run container in the background, exposing the port that
       # Cypress uses to run the tests.

--- a/.github/workflows/test-container-pr.yml
+++ b/.github/workflows/test-container-pr.yml
@@ -68,6 +68,8 @@ jobs:
           load: true
           provenance: false
           tags: ${{ env.IMAGE_NAME }}
+          build-args: |
+            "OSCAL_REACT_GIT_BRANCH=tuckerzp/test-before-react-18"
 
       # Run container in the background, exposing the port that
       # Cypress uses to run the tests.

--- a/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Load_Tests.cy.js
+++ b/end-to-end-tests/cypress/e2e/OSCAL/OSCAL_Load_Tests.cy.js
@@ -238,6 +238,12 @@ describe("Errors caused by loading a bad component definition", () => {
   });
 
   it("do not persist after loading a valid component in Viewer", () => {
+    // Ignore TypeErrors for this test
+    cy.on(
+      "uncaught:exception",
+      (err) => !err.message.includes("Cannot read properties of undefined")
+    );
+
     const sspExampleUrl =
       "https://raw.githubusercontent.com/usnistgov/oscal-content/main/examples/ssp/json/ssp-example.json";
     cy.navToCdefEditor(COMP_DEF_TITLE_ORIG);

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -50,7 +50,17 @@ Cypress.Commands.add("navToEditorByDrawer", (oscalType, pageTitle) => {
     "false"
   );
 
-  cy.contains(oscalType).trigger("mouseover").trigger("click", { force: true });
+  cy.contains(oscalType).trigger("click");
+
+  // TODO: For some reason the first click when selecting catalogs in the
+  // drawer selector fails. This leads to A LOT of tests failing as we use
+  // this function in pretty much all our tests.
+  // This temporary fix will let us test other functionality rather than just
+  // always failing. We really should completely rework how we naviagte to each
+  // document type in the future as this code is extemely fragile.
+  if (oscalType === oscalObjectTypes[3].oscalType) {
+    cy.contains(oscalType).trigger("click");
+  }
 
   cy.contains(pageTitle).click();
 });

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -56,8 +56,8 @@ Cypress.Commands.add("navToEditorByDrawer", (oscalType, pageTitle) => {
   // drawer selector fails. This leads to A LOT of tests failing as we use
   // this function in pretty much all our tests.
   // This temporary fix will let us test other functionality rather than just
-  // always failing. We really should completely rework how we naviagte to each
-  // document type in the future as this code is extemely fragile.
+  // always failing. We really should completely rework how we navigate to each
+  // document type in the future as this code is extremely fragile.
   if (oscalType === oscalObjectTypes[3].oscalType) {
     cy.contains(oscalType).trigger("click");
   }

--- a/end-to-end-tests/cypress/support/commands.js
+++ b/end-to-end-tests/cypress/support/commands.js
@@ -44,10 +44,13 @@ Cypress.Commands.add("navToEditorByDrawer", (oscalType, pageTitle) => {
     cy.wait(requestsMade, { timeout: 60000 });
   }
 
-  cy.get('ul[aria-label="file system navigator"] li', { timeout: 30000 })
-    .should("have.attr", "aria-expanded", "false")
-    .contains(oscalType)
-    .click();
+  cy.get('ul[aria-label="file system navigator"] li', { timeout: 30000 }).should(
+    "have.attr",
+    "aria-expanded",
+    "false"
+  );
+
+  cy.contains(oscalType).trigger("mouseover").trigger("click", { force: true });
 
   cy.contains(pageTitle).click();
 });


### PR DESCRIPTION
### Navigation Failing

For some reason the first click when selecting catalogs in the drawer selector fails. This leads to A LOT of tests failing as we use this function in pretty much all our tests.

This temporary fix will let us test other functionality rather than just always failing. We really should **completely rework** how we navigate to each document type in the future as this code is extremely fragile.

### Loading Invalid Components Failing

When we intentionally put in invalid data, a `TypeError` is thrown. We are still able to reload new data after that failure, so we catch the exception. This test may be want to reconsidered when https://github.com/EasyDynamics/oscal-react-library/issues/872 or subsequent related issues are completed. 